### PR TITLE
DEV-921: add search excerpt for pages that don't have one

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -450,4 +450,19 @@
 		}
 	}
 
+	//truncate text, default character limit is 250
+	//used in search.php for ACF content excerpts
+	function truncate($text, $length = 250) {
+
+		$text = strip_tags($text);
+
+		if (strlen($text) <= $length) {
+			return $text;
+		}
+		$text = substr($text, 0, $length);
+		$text = substr($text, 0, strrpos($text, " "));
+		$text .= "...";
+		return $text;
+	}
+
 	

--- a/functions.php
+++ b/functions.php
@@ -38,7 +38,7 @@
 
 		wp_enqueue_style( 'site-fonts', get_template_directory_uri() . '/fonts.min.css', NULL, filemtime( get_template_directory() . '/fonts.css' ) );
 		if ( 'local' === wp_get_environment_type() ) {
-			wp_enqueue_style( 'firebird-styles', 'https://hathitrust-firebird-common.netlify.app/assets/main.css');
+			wp_enqueue_style( 'firebird-styles', 'https://hathitrust-firebird-common.netlify.app/assets/index.css');
 			wp_enqueue_style( 'site-styles', get_template_directory_uri() . '/src/css/style.css', array( 'site-fonts', 'firebird-styles' ), filemtime( get_template_directory() . '/src/css/style.css' ) );
 		} else {
 			wp_enqueue_style( 'firebird-styles', $firebird_manifest['stylesheet']);
@@ -55,7 +55,7 @@
 		if ( 'local' === wp_get_environment_type() ) {
 			// if you need your local firebird
 			// wp_enqueue_script( 'firebird-scripts', '//localhost:5173/js/main.js', array(), false, false);
-			wp_enqueue_script( 'firebird-scripts', 'https://hathitrust-firebird-common.netlify.app/assets/main.js', array(), false, true);
+			wp_enqueue_script( 'firebird-scripts', 'https://hathitrust-firebird-common.netlify.app/assets/index.js', array(), false, true);
 			wp_enqueue_script( 'site-scripts', get_template_directory_uri() . '/src/js/scripts.js', array('firebird-scripts'), filemtime( get_template_directory() . '/src/js/scripts.js' ), TRUE );
 		} else {
 		//need min version of firebird

--- a/search.php
+++ b/search.php
@@ -59,7 +59,6 @@
 						if (get_row_layout() == 'content' && $i == 0) {
 							$i++;	
 								$text = wp_kses_post( get_sub_field( 'content', false) ); 	
-								var_dump($text);
 								if (strlen($text) > 250) {
 									$truncated_text = substr($text, 0, 250);
 									$last_space = strrpos($truncated_text, " ");

--- a/search.php
+++ b/search.php
@@ -58,7 +58,8 @@
 						
 						if (get_row_layout() == 'content' && $i == 0) {
 							$i++;	
-								$text = wp_kses_post( get_sub_field( 'content', false) ); 	
+								$text = wp_kses_post( get_sub_field( 'content') ); 	
+								$text = strip_tags($text);
 								if (strlen($text) > 250) {
 									$truncated_text = substr($text, 0, 250);
 									$last_space = strrpos($truncated_text, " ");

--- a/search.php
+++ b/search.php
@@ -48,34 +48,39 @@
 				?>
 			   
 				<div><?= the_excerpt(); ?></div>
-			  <?php 
+				<?php 
 			    }  
 			
-			// if there's no excerpt, check the ACF fields for a "content" block and give me the first 250 words with an ellipses at the end
-			if ( have_rows( 'main_blocks' ) ){
-				$i = 0;
-				while ( have_rows( 'main_blocks' ) ){ the_row();
-					
-				if (get_row_layout() == 'content' && $i == 0) {
-					$i++;	
-						//$format_value = false gets rid of the paragraph formatting so the excerpt matches the other excerpt formatting
-						$text = wp_kses_post( get_sub_field( 'content' , $format_value = false) ); 	
-						if (strlen($text) > 250) {
-						$text = substr($text, 0, 250);
-						$last_space = strrpos($text, " ");
-						$text = substr($text, 0, $last_space);
-						$text .= "...";
-						}
-
+				// if there's no excerpt, check the ACF fields for the first "content" block and give me the first 250 words with an ellipses at the end
+				if ( have_rows( 'main_blocks' ) ){
+					$i = 0;
+					while ( have_rows( 'main_blocks' ) ){ the_row();
 						
-					?><div><?= $text; ?></div>
-					
-					<?php
-				
+						if (get_row_layout() == 'content' && $i == 0) {
+							$i++;	
+								//$format_value = false gets rid of the paragraph formatting so the excerpt matches the other excerpt formatting
+								$text = wp_kses_post( get_sub_field( 'content' , $format_value = false) ); 	
+								if (strlen($text) > 250) {
+									$truncated_text = substr($text, 0, 250);
+									$last_space = strrpos($truncated_text, " ");
+									$truncated_text = substr($truncated_text, 0, $last_space);
+									$truncated_text .= "...";
+									
+									$content_excerpt = $truncated_text;
+								} else {
+									$content_excerpt = $text;
+								}
+
+
+								
+							?><div><?= $content_excerpt; ?></div>
+							
+							<?php
+						
+						}
+					}
 				}
-			}
-		}
-		?>
+				?>
 				
 		</article>
 <?php

--- a/search.php
+++ b/search.php
@@ -72,7 +72,7 @@
 
 
 								
-							?><div><?= $content_excerpt; ?></div>
+							?><div class="content-excerpt"><?= $content_excerpt; ?></div>
 							
 							<?php
 						

--- a/search.php
+++ b/search.php
@@ -58,8 +58,7 @@
 						
 						if (get_row_layout() == 'content' && $i == 0) {
 							$i++;	
-								//$format_value = false gets rid of the paragraph formatting so the excerpt matches the other excerpt formatting
-								$text = wp_kses_post( get_sub_field( 'content' , $format_value = false) ); 	
+								$text = wp_kses_post( get_sub_field( 'content') ); 	
 								if (strlen($text) > 250) {
 									$truncated_text = substr($text, 0, 250);
 									$last_space = strrpos($truncated_text, " ");

--- a/search.php
+++ b/search.php
@@ -49,7 +49,7 @@
 			   
 				<div><?= the_excerpt(); ?></div>
 				<?php 
-			    }  
+			    } else {  
 			
 				// if there's no excerpt, check the ACF fields for the first "content" block and give me the first 250 words with an ellipses at the end
 				if ( have_rows( 'main_blocks' ) ){
@@ -58,7 +58,8 @@
 						
 						if (get_row_layout() == 'content' && $i == 0) {
 							$i++;	
-								$text = wp_kses_post( get_sub_field( 'content') ); 	
+								$text = wp_kses_post( get_sub_field( 'content', false) ); 	
+								var_dump($text);
 								if (strlen($text) > 250) {
 									$truncated_text = substr($text, 0, 250);
 									$last_space = strrpos($truncated_text, " ");
@@ -79,6 +80,7 @@
 						}
 					}
 				}
+			}
 				?>
 				
 		</article>

--- a/search.php
+++ b/search.php
@@ -38,7 +38,37 @@
 ?>
 		<article class="search-card pb">
 			<a href="<?= esc_url( get_permalink() ); ?>"><?= esc_html( get_the_title() ); ?></a>
-			<div><?= get_the_excerpt(); ?></div>
+			
+			
+			   <?php 
+				// if the post/page has no excerpt, get_the_excerpt returns an empty string and thus an empty div
+				// so check that the exceprt exists	   
+				if(get_the_excerpt() ) { 
+				
+				?>
+			   
+				<div><?= the_excerpt(); ?></div>
+			  <?php 
+			    }  
+			
+			// if there's no excerpt, check the ACF fields for a "content" block and give me the first 250 words with an ellipses at the end
+			if ( have_rows( 'main_blocks' ) ) {
+				while ( have_rows( 'main_blocks' ) ) { the_row();
+				
+					if (in_array('content', get_row() )) { 
+						//$format_value = false gets rid of the paragraph formatting so the excerpt matches the other excerpt formatting
+						$text = wp_kses_post( get_sub_field( 'content' , $format_value = false) ); 	
+						$truncated_text = substr($text, 0, 250);
+						$last_space = strrpos($truncated_text, " ");
+						$truncated_text = substr($truncated_text, 0, $last_space);
+						$truncated_text .= "...";
+
+						?><div><?= $truncated_text; ?></div>
+						<?php
+					}
+				}
+			}
+			?>
 		</article>
 <?php
 

--- a/search.php
+++ b/search.php
@@ -51,29 +51,15 @@
 				<?php 
 			    } else {  
 			
-				// if there's no excerpt, check the ACF fields for the first "content" block and give me the first 250 words with an ellipses at the end
+				// check the ACF fields for the first "content" block and return the first 250 characters with an ellipses at the end
 				if ( have_rows( 'main_blocks' ) ){
 					$i = 0;
 					while ( have_rows( 'main_blocks' ) ){ the_row();
 						
 						if (get_row_layout() == 'content' && $i == 0) {
 							$i++;	
-								$text = wp_kses_post( get_sub_field( 'content') ); 	
-								$text = strip_tags($text);
-								if (strlen($text) > 250) {
-									$truncated_text = substr($text, 0, 250);
-									$last_space = strrpos($truncated_text, " ");
-									$truncated_text = substr($truncated_text, 0, $last_space);
-									$truncated_text .= "...";
-									
-									$content_excerpt = $truncated_text;
-								} else {
-									$content_excerpt = $text;
-								}
-
-
-								
-							?><div class="content-excerpt"><?= $content_excerpt; ?></div>
+															
+							?><div class="content-excerpt"><p><?= truncate(wp_kses_post( get_sub_field('content'))); ?></p></div>
 							
 							<?php
 						

--- a/search.php
+++ b/search.php
@@ -52,23 +52,31 @@
 			    }  
 			
 			// if there's no excerpt, check the ACF fields for a "content" block and give me the first 250 words with an ellipses at the end
-			if ( have_rows( 'main_blocks' ) ) {
-				while ( have_rows( 'main_blocks' ) ) { the_row();
-				
-					if (in_array('content', get_row() )) { 
+			if ( have_rows( 'main_blocks' ) ){
+				$i = 0;
+				while ( have_rows( 'main_blocks' ) ){ the_row();
+					
+				if (get_row_layout() == 'content' && $i == 0) {
+					$i++;	
 						//$format_value = false gets rid of the paragraph formatting so the excerpt matches the other excerpt formatting
 						$text = wp_kses_post( get_sub_field( 'content' , $format_value = false) ); 	
-						$truncated_text = substr($text, 0, 250);
-						$last_space = strrpos($truncated_text, " ");
-						$truncated_text = substr($truncated_text, 0, $last_space);
-						$truncated_text .= "...";
+						if (strlen($text) > 250) {
+						$text = substr($text, 0, 250);
+						$last_space = strrpos($text, " ");
+						$text = substr($text, 0, $last_space);
+						$text .= "...";
+						}
 
-						?><div><?= $truncated_text; ?></div>
-						<?php
-					}
+						
+					?><div><?= $text; ?></div>
+					
+					<?php
+				
 				}
 			}
-			?>
+		}
+		?>
+				
 		</article>
 <?php
 


### PR DESCRIPTION
_(This should be squash-merged... so many commits for so little code 🙈 )_

## The problem

Wordpress has a built-in "excerpt" feature, but Phire used ACF to create our content pages, so a workaround is necessary. While there is an "excerpt" option in the editor, adding an excerpt to all 150+ pages would be time-consuming.

## The fix

Using ACFs "loop," I'm checking for "content" blocks and returning the first 250 characters of the first content block on the page. If that content has heading or links, those will be stripped from the string before being returned.