### PR TITLE
bug fixes: uncenter images, update section jumper functions

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -171,12 +171,13 @@ h3,
 .bold {
   font-weight: 700;
 }
-.caption, .wp-caption-text {
-  font-size: .75rem;
+.caption,
+.wp-caption-text {
+  font-size: 0.75rem;
   line-height: 1.25;
 }
 .wp-caption-text {
-  margin-top: .75rem;
+  margin-top: 0.75rem;
 }
 .exbold {
   font-weight: 800;
@@ -382,7 +383,7 @@ h3,
   color: var(--primary);
 }
 .twocol-side .has-hl + p {
-  margin-top: .5rem;
+  margin-top: 0.5rem;
 }
 .twocol-main {
   display: grid;
@@ -613,8 +614,11 @@ h3,
 }
 .mainplain p img:only-child {
   display: block;
-  margin: 1.5rem auto;
+  margin: 1.5rem 0;
   border-radius: 0.375rem;
+}
+.mainplain p img.aligncenter {
+  margin: 1.5rem auto;
 }
 .mainplain a:not(.btn, .link-arrow):visited {
   color: var(--secondary);
@@ -738,7 +742,7 @@ h3,
   margin-top: 2rem;
 }
 .pb.widget-container h2 {
-  margin-top:.25rem;
+  margin-top: 0.25rem;
 }
 
 /* cards */

--- a/src/js/scripts.js
+++ b/src/js/scripts.js
@@ -39,18 +39,8 @@
       // phire originally used
       // el.parentElement.getBoundingClientRect().left + window.pageXOffset
       // el.parentElement.getBoundingClientRect().top + window.pageYOffset
-      navmenu.style.setProperty(
-        '--left',
-        `${
-          el.parentElement.offsetLeft
-        }px`
-      );
-      navmenu.style.setProperty(
-        '--top',
-        `${
-          el.parentElement.offsetTop
-        }px`
-      );
+      navmenu.style.setProperty('--left', `${el.parentElement.offsetLeft}px`);
+      navmenu.style.setProperty('--top', `${el.parentElement.offsetTop}px`);
       navmenu.style.setProperty('--width', `${hoverWidth}px`);
       navmenu.style.setProperty('--height', `${hoverHeight}px`);
     }
@@ -235,10 +225,11 @@
 
       slug = el.textContent
         .replace(/ /g, '-')
-        .replace(/[^A-Za-z0-9-]/g, '')
+        .replace(/\./g, '_')
+        .replace(/[^A-Za-z0-9-_]/g, '')
         .toLowerCase();
 
-      if (document.querySelector(`#${slug}`)) {
+      if (document.querySelector(`[id="${slug}"]`)) {
         return;
       }
 
@@ -246,8 +237,8 @@
     });
 
     sj.addEventListener('submit', function (evt) {
-      const sectionID = `#${sj.querySelector('#sj').value}`,
-        target = document.querySelector(sectionID),
+      const sectionID = `${sj.querySelector('#sj').value}`,
+        target = document.querySelector(`[id="${sectionID}"]`),
         pageURL = new URL(document.URL);
 
       evt.preventDefault();


### PR DESCRIPTION
## uncenter images
see [TTO-133](https://hathitrust.atlassian.net/browse/TTO-133)

Problem: Images within paragraphs (because it's wordpress, this is most images 🙃) that are "only children" (no sibling elements-- again, most of them) were being centered aligned, even if the user was choosing a different alignment in the editor. 

Fix: lines 615-622 of `style.css`; take the auto margin off the image, put the auto margin back for images which are center-aligned by user in the editor.

## update section jumper functions

Problem: if a heading used in the "section jumper" starts with numbers, any `querySelector` methods trying to use the generated IDs gets mad and the `setupSectionJumper` function returns without removing the "hidden" attribute from the section jumper element. This specific example is the heading "2.0 Technical Considerations." `querySelector` [doesn't work with leading numbers](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/id) unless you use the attribute property/value method instead of CSS selector notation (`id=['2_0-technical-considerations']` vs `#2_0-technical-considerations`). 

Fixes: 

- lines 232, 241: I updated those functions to use the attribute property/value names instead of `#`.
- lines 228, 229: I also added a `.replace()` method to turn the `.` in the heading into an `_` instead of removing it (so the URL of the section anchor makes more sense to a human who might be reading it). I then had to add the underscore to the regex of the following `.replace()` to include underscores. 