### PR TITLE
Migrate widgets to wordpress

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -21,6 +21,7 @@
 
 	/**
 	 *  Enqueues the global styles and scripts.
+	 *  Generally, use minimized styles/scripts in prod and unminimized files for local development.
 	 */
 	function pg_enqueue_site_files() {
 
@@ -36,35 +37,47 @@
 			$firebird_manifest['script'] = '/common/firebird/dist/' . $firebird_config['index.html']['file'];
 		}
 
+		/*
+		STYLES
+		*/ 
+
+		/* fonts, firebird, theme styles */
 		wp_enqueue_style( 'site-fonts', get_template_directory_uri() . '/fonts.min.css', NULL, filemtime( get_template_directory() . '/fonts.css' ) );
+		wp_enqueue_style( 'firebird-styles', $firebird_manifest['stylesheet']);
 		if ( 'local' === wp_get_environment_type() ) {
-			wp_enqueue_style( 'firebird-styles', 'https://hathitrust-firebird-common.netlify.app/assets/index.css');
 			wp_enqueue_style( 'site-styles', get_template_directory_uri() . '/src/css/style.css', array( 'site-fonts', 'firebird-styles' ), filemtime( get_template_directory() . '/src/css/style.css' ) );
 		} else {
-			wp_enqueue_style( 'firebird-styles', $firebird_manifest['stylesheet']);
 			wp_enqueue_style( 'site-styles', get_template_directory_uri() . '/dist/css/style.min.css', array( 'site-fonts', 'firebird-styles' ), filemtime( get_template_directory() . '/dist/css/style.min.css' ) );
 		}	
 
-
+		/* homepage styles */
 		if ( is_front_page() && 'local' === wp_get_environment_type() ) {
 			wp_enqueue_style( 'home-styles', get_template_directory_uri() . '/src/css/home.css', array( 'site-fonts', 'site-styles', 'firebird-styles'), filemtime( get_template_directory() . '/src/css/home.css' ) );
 		} else if ( is_front_page() ) {
 			wp_enqueue_style( 'home-styles', get_template_directory_uri() . '/dist/css/home.min.css', array( 'site-fonts', 'site-styles', 'firebird-styles' ), filemtime( get_template_directory() . '/dist/css/home.min.css' ) );
 		}
 
+		/* 
+		SCRIPTS
+		*/
+
+		/* matomo */
+		if ( 'development' === wp_get_environment_type() || 'staging' === wp_get_environment_type() ) {
+			wp_enqueue_script( 'testing-matomo-script', get_template_directory_uri() . '/src/js/testing-matomo.js', array('firebird-scripts'), filemtime( get_template_directory() . '/src/js/testing-matomo.js' ));
+		} 
+		if ( 'production' === wp_get_environment_type() ) {
+			wp_enqueue_script( 'matomo-script', get_template_directory_uri() . '/src/js/matomo.js', array('firebird-scripts'), filemtime( get_template_directory() . '/src/js/matomo.js' ));
+		}
+
+		/* theme and firebird scripts */
+		  wp_enqueue_script('firebird-scripts', $firebird_manifest['script'], array(), false, false);
 		if ( 'local' === wp_get_environment_type() ) {
 			// if you need your local firebird
 			// wp_enqueue_script( 'firebird-scripts', '//localhost:5173/js/main.js', array(), false, false);
-			wp_enqueue_script( 'firebird-scripts', 'https://hathitrust-firebird-common.netlify.app/assets/index.js', array(), false, true);
 			wp_enqueue_script( 'site-scripts', get_template_directory_uri() . '/src/js/scripts.js', array('firebird-scripts'), filemtime( get_template_directory() . '/src/js/scripts.js' ), TRUE );
 		} else {
-		//need min version of firebird
-		// wp_enqueue_script( 'firebird-scripts', 'https://hathitrust-firebird-common.netlify.app/assets/main.js', array(), false, false);
-
-		  wp_enqueue_script('firebird-scripts', $firebird_manifest['script'], array(), false, false);
 
 			wp_enqueue_script( 'site-scripts', get_template_directory_uri() . '/dist/js/scripts.min.js', array('firebird-scripts'), filemtime( get_template_directory() . '/dist/js/scripts.min.js' ), TRUE );
-			wp_enqueue_script( 'matomo-script', get_template_directory_uri() . '/src/js/matomo.js', array('firebird-scripts'), filemtime( get_template_directory() . '/src/js/matomo.js' ));
 			// hotjar script is added through firebird-common + ping
 		}
 

--- a/page-searchbox_catalog.php
+++ b/page-searchbox_catalog.php
@@ -1,0 +1,50 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html lang="en">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <title>Search HathiTrust Catalog</title>
+<meta name="ROBOTS" content="NOINDEX,NOFOLLOW" />
+<link rel="stylesheet" href="/wp-content/themes/wordpress-hathitrust/fonts.min.css" media="all"/>
+<!-- <link rel="stylesheet" href="/wp-content/themes/wordpress-hathitrust/dist/css/style.min.css" media="all"/> -->
+<style type="text/css">
+  body,
+  html {
+    margin: 0;
+    padding: 0;
+    font: 500 medium/1.31 Mulish, sans-serif;
+  }
+  button, input {
+    font: 500 medium/1.31 Mulish, sans-serif;
+    margin:0;
+  }
+  /* img {
+        width: auto;
+        height: 5rem;
+        padding: 1rem;
+      } */
+
+  
+  .offscreen {
+    position: absolute !important;
+    height: 1px;
+    width: 1px;
+    overflow: hidden;
+    clip: rect(1px 1px 1px 1px);
+    clip: rect(1px, 1px, 1px, 1px)
+  }
+</style>
+<body>
+  <main style="display:flex;width:290px;height:26px;gap:3px;">
+      <img src="https://babel.hathitrust.org/common/firebird/dist/cropped-favicon-180x180.png" alt="HathiTrust search widget"/>
+        <h1 class="offscreen">Search HathiTrust Digital Library Catalog</h1>
+        <form style="display:flex;gap:3px" method="get" action="https://catalog.hathitrust.org/Search/Home" id="HT_CatalogSearchForm_02" name="HT_CatalogSearchForm_02" target="_blank">
+            <input type="hidden" name="checkspelling" value="true"/>
+            <input type="hidden" name="type" value="all"/>
+            <label for="q" class="offscreen">Search Terms</label>
+            <input style="width:100%" class="searchterms" type="text" name="lookfor" value="" id="q"/>
+            <button type="submit" name="submit" id="searchSubmit">Find</button>
+        </form>
+  
+</main>
+  <script type="text/javascript" src="/wp-content/themes/wordpress-hathitrust/src/js/matomo.js"></script>
+</body></html>

--- a/page-searchbox_catalog_fv.php
+++ b/page-searchbox_catalog_fv.php
@@ -1,0 +1,67 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<head>
+<html lang="en">
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<title>Search HathiTrust Catalog</title>
+<meta name="ROBOTS" content="NOINDEX,NOFOLLOW" />
+<link rel="stylesheet" href="/wp-content/themes/wordpress-hathitrust/fonts.min.css" media="all"/>
+<style type="text/css">
+  body,
+  html {
+    margin: 0;
+    padding: 0;
+    font: 500 medium/1.31 Mulish, sans-serif;
+  }
+   button, input {
+    font: 500 medium/1.31 Mulish, sans-serif;
+    font-size:13px;
+  }
+  input[type="checkbox" i] {
+    margin-inline-start:0;
+  }
+  img {
+        width:55px;
+        height:auto;
+  }
+  h1 {
+    font-size:12px;
+    line-height:1.1;
+    margin: 0;
+    margin-block-end:5px;
+  }
+  .offscreen {
+    position: absolute !important;
+    height: 1px;
+    width: 1px;
+    overflow: hidden;
+    clip: rect(1px 1px 1px 1px);
+    clip: rect(1px, 1px, 1px, 1px)
+  }
+</style>
+<body>
+  <main>
+    <div style="display:flex;align-items:center;max-height:60px;max-width:300px;gap:7px;">
+      <img src="https://babel.hathitrust.org/common/firebird/dist/hathitrust-icon-orange.svg" alt="HathiTrust search widget"/>
+      <div style="">
+        <h1>Search HathiTrust Digital Library Catalog</h1>
+        <form method="get" action="https://catalog.hathitrust.org/Search/Home" id="HT_CatalogSearchForm_03" name="HT_CatalogSearchForm_03" target="_blank">
+              <input type="hidden" name="checkspelling" value="true"/>
+              <input type="hidden" name="type" value="all"/>
+              <label for="q" class="offscreen">Search Terms</label>
+              <div style="display:flex;gap:5px;">
+                <input style="flex-grow:2" class="searchterms" type="text" name="lookfor" value="" id="q"/>
+                <button type="submit" name="submit" id="searchSubmit">Find</button>
+              </div>
+              <div style="display:flex;align-items:center;margin-block-start:3px;gap:3px;">
+                <input type="hidden" name="sethtftonly" value="true"/>
+                <input type="checkbox" name="htftonly" value="true" id="fullonly" checked="yes" />
+                <label for="fullonly" style="position: relative; font-size: 75%;">Full view only</label>
+              </div>
+        </form>
+      </div>
+
+    </div>
+  
+</main>
+<script type="text/javascript" src="/wp-content/themes/wordpress-hathitrust/src/js/matomo.js"></script>
+</body></html>

--- a/page-searchbox_catalog_fv.php
+++ b/page-searchbox_catalog_fv.php
@@ -54,7 +54,7 @@
               </div>
               <div style="display:flex;align-items:center;margin-block-start:3px;gap:3px;">
                 <input type="hidden" name="sethtftonly" value="true"/>
-                <input type="checkbox" name="htftonly" value="true" id="fullonly" checked="yes" />
+                <input type="checkbox" name="htftonly" value="true" id="fullonly" checked="checked" />
                 <label for="fullonly" style="position: relative; font-size: 75%;">Full view only</label>
               </div>
         </form>

--- a/page-searchbox_fulltext.php
+++ b/page-searchbox_fulltext.php
@@ -1,0 +1,42 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html lang="en">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<title>Search HathiTrust Digital Library Full Text</title>
+<meta name="ROBOTS" content="NOINDEX,NOFOLLOW" />
+<link rel="stylesheet" href="/wp-content/themes/wordpress-hathitrust/fonts.min.css" media="all"/>
+<style type="text/css">
+  body,
+  html {
+    margin: 0;
+    padding: 0;
+    font: 500 medium/1.31 Mulish, sans-serif;
+  }
+   button, input {
+    font: 500 medium/1.31 Mulish, sans-serif;
+  }
+  .offscreen {
+    position: absolute !important;
+    height: 1px;
+    width: 1px;
+    overflow: hidden;
+    clip: rect(1px 1px 1px 1px);
+    clip: rect(1px, 1px, 1px, 1px)
+  }
+</style>
+<body>
+  <main style="display:flex;width:290px;height:26px;gap:3px;">
+        <img src="https://babel.hathitrust.org/common/firebird/dist/cropped-favicon-180x180.png" alt="HathiTrust search widget"/>
+        <h1 class="offscreen" >Search HathiTrust Digital Library Full Text</h1>
+        <form style="display:flex;gap:3px;"name="searchcoll" action="https://babel.hathitrust.org/cgi/ls" id="HT_FullTextSearchForm_01" target="_blank">
+          <!-- <div style="position: relative;"> -->
+            <input type="hidden" value="srchls" name="a"/>
+            <label for="q" class="offscreen">Search Terms</label>
+            <input style="width:100%" class="searchterms" type="text" value="" name="q1" id="q"/>
+            <button id="srch" type="submit">Find</button>
+          <!-- </div> -->
+        </form>
+</main>
+<script type="text/javascript" src="/wp-content/themes/wordpress-hathitrust/src/js/matomo.js"></script>
+</body>
+</html>

--- a/page-searchbox_fulltext_fv.php
+++ b/page-searchbox_fulltext_fv.php
@@ -52,7 +52,7 @@
                 <button id="srch" type="submit">Find</button>
               </div>
               <div style="display:flex;align-items:center;margin-block-start:3px;gap:3px;">
-                <input type="checkbox" value="ft" name="lmt" id="ls_fullonly" checked="yes" />
+                <input type="checkbox" value="ft" name="lmt" id="ls_fullonly" checked="checked" />
                 <label for="ls_fullonly" style="position: relative; font-size: 75%;">Full view only</label>
                 <input type="hidden" value="srchls" name="a"/>
               </div>

--- a/page-searchbox_fulltext_fv.php
+++ b/page-searchbox_fulltext_fv.php
@@ -1,0 +1,65 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html lang="en">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<title>Search HathiTrust Digital Library Full Text</title>
+<meta name="ROBOTS" content="NOINDEX,NOFOLLOW" />
+<link rel="stylesheet" href="/wp-content/themes/wordpress-hathitrust/fonts.min.css" media="all"/>
+<style type="text/css">
+  body,
+  html {
+    margin: 0;
+    padding: 0;
+    font: 500 medium/1.31 Mulish, sans-serif;
+  }
+   button, input {
+    font: 500 medium/1.31 Mulish, sans-serif;
+    font-size:13px;
+  }
+  input[type="checkbox" i] {
+    margin-inline-start:0;
+  }
+  img {
+        width:55px;
+        height:auto;
+  }
+  h1 {
+    font-size:11.5px;
+    line-height:1.1;
+    margin: 0;
+    margin-block-end:5px;
+  }
+  .offscreen {
+    position: absolute !important;
+    height: 1px;
+    width: 1px;
+    overflow: hidden;
+    clip: rect(1px 1px 1px 1px);
+    clip: rect(1px, 1px, 1px, 1px)
+  }
+</style>
+<body>
+  <main>
+    <div style="display:flex;align-items:center;max-height:60px;max-width:300px;gap:7px;">
+      <img src="https://babel.hathitrust.org/common/firebird/dist/hathitrust-icon-orange.svg" alt="HathiTrust search widget"/>
+      <div style="">
+        <h1>Search HathiTrust Digital Library Full Text</h1>
+          <form name="searchcoll" action="https://babel.hathitrust.org/cgi/ls" id="HT_FullTextSearchForm_02" target="_blank">
+              <input type="hidden" value="srchls" name="a"/>
+              <label for="q" class="offscreen">Search Terms</label>
+              <div style="display:flex;gap:5px;">
+                <input class="searchterms" type="text" style="flex-grow:2" value="" name="q1" id="q"/>
+                <button id="srch" type="submit">Find</button>
+              </div>
+              <div style="display:flex;align-items:center;margin-block-start:3px;gap:3px;">
+                <input type="checkbox" value="ft" name="lmt" id="ls_fullonly" checked="yes" />
+                <label for="ls_fullonly" style="position: relative; font-size: 75%;">Full view only</label>
+                <input type="hidden" value="srchls" name="a"/>
+              </div>
+          </form>
+        </div>
+    </div>
+  </main>
+  <script type="text/javascript" src="/wp-content/themes/wordpress-hathitrust/src/js/matomo.js"></script>
+</body>
+</html>

--- a/page-searchbox_multi.php
+++ b/page-searchbox_multi.php
@@ -1,11 +1,11 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <title>Search HathiTrust Catalog</title>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-    <meta name="ROBOTS" content="NOINDEX,NOFOLLOW" />
-    <link rel="stylesheet" href="/wp-content/themes/wordpress-hathitrust/fonts.min.css" media="all"/>
-    <style type="text/css">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta name="ROBOTS" content="NOINDEX,NOFOLLOW">
+    <link rel="stylesheet" href="/wp-content/themes/wordpress-hathitrust/fonts.min.css" media="all">
+    <style>
       body,
       html {
         margin: 0;
@@ -26,7 +26,7 @@
         font-size:12.5px;
         line-height:1.1;
         margin:0;
-        margin-block-end:5px;
+        margin-block-end:3px;
       }
       .offscreen {
         position: absolute !important;
@@ -40,21 +40,13 @@
   </head>
   <body>
     <main style="display:flex;max-height:90px;width:450px;gap:.5rem;">
-        <img src="https://babel.hathitrust.org/common/firebird/dist/hathitrust-icon-orange.svg" alt="HathiTrust widget search" />
+        <img src="https://babel.hathitrust.org/common/firebird/dist/hathitrust-icon-orange.svg" alt="HathiTrust widget search">
         <div style="width:100%;">
           <h1>Search HathiTrust Digital Library Catalog</h1>
-          <div>
-            <form
-              method="get"
-              action="https://catalog.hathitrust.org/Search/Home"
-              name="HT_CatalogSearchForm_01"
-              class="search"
-              id="widget-catalog-multi" 
-              target="_blank"
-            >
+          <form method="get" action="https://catalog.hathitrust.org/Search/Home" name="HT_CatalogSearchForm_01" class="search" id="widget-catalog-multi" target="_blank">
               <div >
-                <input type="hidden" name="checkspelling" value="true" />
-                <input type="hidden" name="type" value="all" />
+                <input type="hidden" name="checkspelling" value="true">
+                <input type="hidden" name="type" value="all">
                 <label for="lookfor" class="offscreen">Search Terms</label>
                 <div style="display:flex;gap:5px;">
                   <input
@@ -63,81 +55,73 @@
                     name="lookfor"
                     value=""
                     id="lookfor"
-                   style="flex-grow:2" 
-                  />
+                    style="flex-grow:2" 
+                  >
                   <button type="submit" name="submit" id="searchSubmit" >Find</button>
                 </div>
               </div>
               <div style="display:flex;justify-content:space-between;gap:10px;margin-block:3px">
                 <label class="offscreen" for="searchtype">Field Name</label>
-                <select style="flex-grow:2" id="searchtype" name="type" >
+                <select style="flex-grow:2" id="searchtype" name="type">
                   <option value="all">All Fields</option>
                   <option value="title">Title</option>
                   <option value="author">Author</option>
                   <option value="subject">Subject</option>
-                  <!--<option value="hlb">Academic Discipline</option>-->
-                  <!--<option value="callnumber">Call Number / in progress</option>-->
                   <option value="isn">ISBN/ISSN</option>
                   <option value="publisher">Publisher</option>
                   <option value="series">Series Title</option>
                   <option value="year">Year of Publication</option>
-                  <!-- <option value="tag">Tag</option> -->
                 </select>
-                  <div style="display:flex;align-items:center;gap:3px;">
-                  <input type="hidden" name="sethtftonly" value="true" />
+                <div style="display:flex;align-items:center;gap:3px;">
+                  <input type="hidden" name="sethtftonly" value="true">
                   <input
                     type="checkbox"
                     name="htftonly"
                     value="true"
                     id="fullonly"
-                    checked="yes"
-                    
-                  /><label
+                    checked="checked"
+                  ><label
                     for="fullonly"
                     style="font-size:75%;"
-                    
                     >Full view only</label
                   >
                 </div>
               </div>
-              </div>
-              <div >
-                <label class="offscreen" for="searchfilter">Filter by Library</label>
-                <select style="width:100%" id="searchfilter" name="filter[]" >
-                  <option value="">All Libraries</option>
-                  <option value="htsource:Boston College">Boston College</option>
-                  <option value="htsource:Columbia University">Columbia University</option>
-                  <option value="htsource:Cornell University">Cornell University</option>
-                  <option value="htsource:Duke University">Duke University</option>
-                  <option value="htsource:Harvard University">Harvard University</option>
-                  <option value="htsource:Indiana University">Indiana University</option>
-                  <option value="htsource:Library of Congress">Library of Congress</option>
-                  <option value="htsource:Minnesota Digital Library">Minnesota Digital Library</option>
-                  <option value="htsource:New York Public Library">New York Public Library</option>
-                  <option value="htsource:North Carolina State University">North Carolina State University</option>
-                  <option value="htsource:Northwestern University">Northwestern University</option>
-                  <option value="htsource:Penn State University">Penn State University</option>
-                  <option value="htsource:Princeton University">Princeton University</option>
-                  <option value="htsource:Purdue University">Purdue University</option>
-                  <option value="htsource:Universidad Complutense de Madrid">Universidad Complutense de Madrid</option>
-                  <option value="htsource:University of California">University of California</option>
-                  <option value="htsource:University of Chicago">University of Chicago</option>
-                  <option value="htsource:University of Florida">University of Florida</option>
-                  <option value="htsource:University of Illinois">University of Illinois</option>
-                  <option value="htsource:University of Michigan">University of Michigan</option>
-                  <option value="htsource:University of Minnesota">University of Minnesota</option>
-                  <option value="htsource:University of North Carolina">University of North Carolina</option>
-                  <option value="htsource:University of Virginia">University of Virginia</option>
-                  <option value="htsource:University of Wisconsin">University of Wisconsin</option>
-                  <option value="htsource:Utah State University Press">Utah State University Press</option>
-                  <option value="htsource:Yale University">Yale University</option>
-                </select>
-              </div>
-            </form>
-          </div>
+            <div>
+              <label class="offscreen" for="searchfilter">Filter by Library</label>
+              <select style="width:100%" id="searchfilter" name="filter[]" >
+                <option value="">All Libraries</option>
+                <option value="htsource:Boston College">Boston College</option>
+                <option value="htsource:Columbia University">Columbia University</option>
+                <option value="htsource:Cornell University">Cornell University</option>
+                <option value="htsource:Duke University">Duke University</option>
+                <option value="htsource:Harvard University">Harvard University</option>
+                <option value="htsource:Indiana University">Indiana University</option>
+                <option value="htsource:Library of Congress">Library of Congress</option>
+                <option value="htsource:Minnesota Digital Library">Minnesota Digital Library</option>
+                <option value="htsource:New York Public Library">New York Public Library</option>
+                <option value="htsource:North Carolina State University">North Carolina State University</option>
+                <option value="htsource:Northwestern University">Northwestern University</option>
+                <option value="htsource:Penn State University">Penn State University</option>
+                <option value="htsource:Princeton University">Princeton University</option>
+                <option value="htsource:Purdue University">Purdue University</option>
+                <option value="htsource:Universidad Complutense de Madrid">Universidad Complutense de Madrid</option>
+                <option value="htsource:University of California">University of California</option>
+                <option value="htsource:University of Chicago">University of Chicago</option>
+                <option value="htsource:University of Florida">University of Florida</option>
+                <option value="htsource:University of Illinois">University of Illinois</option>
+                <option value="htsource:University of Michigan">University of Michigan</option>
+                <option value="htsource:University of Minnesota">University of Minnesota</option>
+                <option value="htsource:University of North Carolina">University of North Carolina</option>
+                <option value="htsource:University of Virginia">University of Virginia</option>
+                <option value="htsource:University of Wisconsin">University of Wisconsin</option>
+                <option value="htsource:Utah State University Press">Utah State University Press</option>
+                <option value="htsource:Yale University">Yale University</option>
+              </select>
+            </div>
+          </form>
         </div>
     </main>
-    
-    <script type="text/javascript" src="/wp-content/themes/wordpress-hathitrust/src/js/matomo.js"></script>
+    <script src="/wp-content/themes/wordpress-hathitrust/src/js/matomo.js"></script>
   </body>
 </html>

--- a/page-searchbox_multi.php
+++ b/page-searchbox_multi.php
@@ -4,15 +4,29 @@
     <title>Search HathiTrust Catalog</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta name="ROBOTS" content="NOINDEX,NOFOLLOW" />
+    <link rel="stylesheet" href="/wp-content/themes/wordpress-hathitrust/fonts.min.css" media="all"/>
     <style type="text/css">
       body,
       html {
         margin: 0;
         padding: 0;
+        font: 500 medium/1.31 Mulish, sans-serif;
+      }
+      button, select, input {
+        font: 500 medium/1.31 Mulish, sans-serif;
+        font-size:13px;
+      }
+      select {
+        font-size:80%;
       }
       img {
-        width: auto;
-        height: 100%;
+        width: 6rem;
+      }
+      h1 {
+        font-size:12.5px;
+        line-height:1.1;
+        margin:0;
+        margin-block-end:5px;
       }
       .offscreen {
         position: absolute !important;
@@ -25,110 +39,105 @@
     </style>
   </head>
   <body>
-    <main>
-      <h1 class="offscreen">Search HathiTrust Digital Library Catalog</h1>
-      <div
-        style="
-          display: flex;
-          justify-content: space-between;
-          height: 72px;
-          width: 325px;
-          border: 1px solid #ccc;
-          padding: 6px;
-          background-color: #fff;
-        "
-      >
-        <img src="https://babel.hathitrust.org/common/firebird/dist/hathitrust-icon-orange.svg" alt="logo" />
-        <!-- <div style="width: 145px; float: left; margin: 11px 12px 0px 0px"> -->
-        <!-- <img src="/sites/www.hathitrust.org/partial/widgets/images/HathiTrust_WLogo_CatPrtnrs.png" height="47" width="145" alt="Hathi Trust Catalog Search" /> -->
-        <div style="display: inline">
-          <form
-            method="get"
-            action="https://catalog.hathitrust.org/Search/Home"
-            name="HT_CatalogSearchForm_01"
-            class="search"
-            style="display: inline"
-            target="_blank"
-          >
-            <div style="margin-bottom: 3px">
-              <input type="hidden" name="checkspelling" value="true" />
-              <input type="hidden" name="type" value="all" />
-              <label for="lookfor" class="offscreen">Search Terms</label>
-              <input
-                class="searchterms"
-                type="text"
-                name="lookfor"
-                value=""
-                id="lookfor"
-                style="font-size: 13px; width: 184px"
-              />
-              <button type="submit" name="submit" id="searchSubmit" style="font-size: 13px">Find</button>
-            </div>
-            <div style="margin-bottom: 3px">
-              <label class="offscreen" for="searchtype">Field Name</label>
-              <select id="searchtype" name="type" style="font-size: 13px">
-                <option value="all">All Fields</option>
-                <option value="title">Title</option>
-                <option value="author">Author</option>
-                <option value="subject">Subject</option>
-                <!--<option value="hlb">Academic Discipline</option>-->
-                <!--<option value="callnumber">Call Number / in progress</option>-->
-                <option value="isn">ISBN/ISSN</option>
-                <option value="publisher">Publisher</option>
-                <option value="series">Series Title</option>
-                <option value="year">Year of Publication</option>
-                <!-- <option value="tag">Tag</option> -->
-              </select>
-              <input type="hidden" name="sethtftonly" value="true" />
-              <input
-                type="checkbox"
-                name="htftonly"
-                value="true"
-                id="fullonly"
-                checked="yes"
-                style="position: relative; font-size: 13px"
-              />&nbsp;<label
-                for="fullonly"
-                style="position: relative; font-family: Arial, Verdana, Helvetica, sans-serif; font-size: 12px"
-                >Full view only</label
-              >
-            </div>
-            <div style="margin-bottom: 2px">
-              <label class="offscreen" for="searchfilter">Filter by Library</label>
-              <select id="searchfilter" name="filter[]" style="font-size: 13px; width: 238px">
-                <option value="">All Libraries</option>
-                <option value="htsource:Boston College">Boston College</option>
-                <option value="htsource:Columbia University">Columbia University</option>
-                <option value="htsource:Cornell University">Cornell University</option>
-                <option value="htsource:Duke University">Duke University</option>
-                <option value="htsource:Harvard University">Harvard University</option>
-                <option value="htsource:Indiana University">Indiana University</option>
-                <option value="htsource:Library of Congress">Library of Congress</option>
-                <option value="htsource:Minnesota Digital Library">Minnesota Digital Library</option>
-                <option value="htsource:New York Public Library">New York Public Library</option>
-                <option value="htsource:North Carolina State University">North Carolina State University</option>
-                <option value="htsource:Northwestern University">Northwestern University</option>
-                <option value="htsource:Penn State University">Penn State University</option>
-                <option value="htsource:Princeton University">Princeton University</option>
-                <option value="htsource:Purdue University">Purdue University</option>
-                <option value="htsource:Universidad Complutense de Madrid">Universidad Complutense de Madrid</option>
-                <option value="htsource:University of California">University of California</option>
-                <option value="htsource:University of Chicago">University of Chicago</option>
-                <option value="htsource:University of Florida">University of Florida</option>
-                <option value="htsource:University of Illinois">University of Illinois</option>
-                <option value="htsource:University of Michigan">University of Michigan</option>
-                <option value="htsource:University of Minnesota">University of Minnesota</option>
-                <option value="htsource:University of North Carolina">University of North Carolina</option>
-                <option value="htsource:University of Virginia">University of Virginia</option>
-                <option value="htsource:University of Wisconsin">University of Wisconsin</option>
-                <option value="htsource:Utah State University Press">Utah State University Press</option>
-                <option value="htsource:Yale University">Yale University</option>
-              </select>
-            </div>
-          </form>
+    <main style="display:flex;max-height:90px;width:450px;gap:.5rem;">
+        <img src="https://babel.hathitrust.org/common/firebird/dist/hathitrust-icon-orange.svg" alt="HathiTrust widget search" />
+        <div style="width:100%;">
+          <h1>Search HathiTrust Digital Library Catalog</h1>
+          <div>
+            <form
+              method="get"
+              action="https://catalog.hathitrust.org/Search/Home"
+              name="HT_CatalogSearchForm_01"
+              class="search"
+              id="widget-catalog-multi" 
+              target="_blank"
+            >
+              <div >
+                <input type="hidden" name="checkspelling" value="true" />
+                <input type="hidden" name="type" value="all" />
+                <label for="lookfor" class="offscreen">Search Terms</label>
+                <div style="display:flex;gap:5px;">
+                  <input
+                    class="searchterms"
+                    type="text"
+                    name="lookfor"
+                    value=""
+                    id="lookfor"
+                   style="flex-grow:2" 
+                  />
+                  <button type="submit" name="submit" id="searchSubmit" >Find</button>
+                </div>
+              </div>
+              <div style="display:flex;justify-content:space-between;gap:10px;margin-block:3px">
+                <label class="offscreen" for="searchtype">Field Name</label>
+                <select style="flex-grow:2" id="searchtype" name="type" >
+                  <option value="all">All Fields</option>
+                  <option value="title">Title</option>
+                  <option value="author">Author</option>
+                  <option value="subject">Subject</option>
+                  <!--<option value="hlb">Academic Discipline</option>-->
+                  <!--<option value="callnumber">Call Number / in progress</option>-->
+                  <option value="isn">ISBN/ISSN</option>
+                  <option value="publisher">Publisher</option>
+                  <option value="series">Series Title</option>
+                  <option value="year">Year of Publication</option>
+                  <!-- <option value="tag">Tag</option> -->
+                </select>
+                  <div style="display:flex;align-items:center;gap:3px;">
+                  <input type="hidden" name="sethtftonly" value="true" />
+                  <input
+                    type="checkbox"
+                    name="htftonly"
+                    value="true"
+                    id="fullonly"
+                    checked="yes"
+                    
+                  /><label
+                    for="fullonly"
+                    style="font-size:75%;"
+                    
+                    >Full view only</label
+                  >
+                </div>
+              </div>
+              </div>
+              <div >
+                <label class="offscreen" for="searchfilter">Filter by Library</label>
+                <select style="width:100%" id="searchfilter" name="filter[]" >
+                  <option value="">All Libraries</option>
+                  <option value="htsource:Boston College">Boston College</option>
+                  <option value="htsource:Columbia University">Columbia University</option>
+                  <option value="htsource:Cornell University">Cornell University</option>
+                  <option value="htsource:Duke University">Duke University</option>
+                  <option value="htsource:Harvard University">Harvard University</option>
+                  <option value="htsource:Indiana University">Indiana University</option>
+                  <option value="htsource:Library of Congress">Library of Congress</option>
+                  <option value="htsource:Minnesota Digital Library">Minnesota Digital Library</option>
+                  <option value="htsource:New York Public Library">New York Public Library</option>
+                  <option value="htsource:North Carolina State University">North Carolina State University</option>
+                  <option value="htsource:Northwestern University">Northwestern University</option>
+                  <option value="htsource:Penn State University">Penn State University</option>
+                  <option value="htsource:Princeton University">Princeton University</option>
+                  <option value="htsource:Purdue University">Purdue University</option>
+                  <option value="htsource:Universidad Complutense de Madrid">Universidad Complutense de Madrid</option>
+                  <option value="htsource:University of California">University of California</option>
+                  <option value="htsource:University of Chicago">University of Chicago</option>
+                  <option value="htsource:University of Florida">University of Florida</option>
+                  <option value="htsource:University of Illinois">University of Illinois</option>
+                  <option value="htsource:University of Michigan">University of Michigan</option>
+                  <option value="htsource:University of Minnesota">University of Minnesota</option>
+                  <option value="htsource:University of North Carolina">University of North Carolina</option>
+                  <option value="htsource:University of Virginia">University of Virginia</option>
+                  <option value="htsource:University of Wisconsin">University of Wisconsin</option>
+                  <option value="htsource:Utah State University Press">Utah State University Press</option>
+                  <option value="htsource:Yale University">Yale University</option>
+                </select>
+              </div>
+            </form>
+          </div>
         </div>
-      </div>
     </main>
+    
     <script type="text/javascript" src="/wp-content/themes/wordpress-hathitrust/src/js/matomo.js"></script>
   </body>
 </html>

--- a/page-searchbox_multi.php
+++ b/page-searchbox_multi.php
@@ -1,0 +1,134 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html lang="en">
+  <head>
+    <title>Search HathiTrust Catalog</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="ROBOTS" content="NOINDEX,NOFOLLOW" />
+    <style type="text/css">
+      body,
+      html {
+        margin: 0;
+        padding: 0;
+      }
+      img {
+        width: auto;
+        height: 100%;
+      }
+      .offscreen {
+        position: absolute !important;
+        height: 1px;
+        width: 1px;
+        overflow: hidden;
+        clip: rect(1px 1px 1px 1px);
+        clip: rect(1px, 1px, 1px, 1px);
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1 class="offscreen">Search HathiTrust Digital Library Catalog</h1>
+      <div
+        style="
+          display: flex;
+          justify-content: space-between;
+          height: 72px;
+          width: 325px;
+          border: 1px solid #ccc;
+          padding: 6px;
+          background-color: #fff;
+        "
+      >
+        <img src="https://babel.hathitrust.org/common/firebird/dist/hathitrust-icon-orange.svg" alt="logo" />
+        <!-- <div style="width: 145px; float: left; margin: 11px 12px 0px 0px"> -->
+        <!-- <img src="/sites/www.hathitrust.org/partial/widgets/images/HathiTrust_WLogo_CatPrtnrs.png" height="47" width="145" alt="Hathi Trust Catalog Search" /> -->
+        <div style="display: inline">
+          <form
+            method="get"
+            action="https://catalog.hathitrust.org/Search/Home"
+            name="HT_CatalogSearchForm_01"
+            class="search"
+            style="display: inline"
+            target="_blank"
+          >
+            <div style="margin-bottom: 3px">
+              <input type="hidden" name="checkspelling" value="true" />
+              <input type="hidden" name="type" value="all" />
+              <label for="lookfor" class="offscreen">Search Terms</label>
+              <input
+                class="searchterms"
+                type="text"
+                name="lookfor"
+                value=""
+                id="lookfor"
+                style="font-size: 13px; width: 184px"
+              />
+              <button type="submit" name="submit" id="searchSubmit" style="font-size: 13px">Find</button>
+            </div>
+            <div style="margin-bottom: 3px">
+              <label class="offscreen" for="searchtype">Field Name</label>
+              <select id="searchtype" name="type" style="font-size: 13px">
+                <option value="all">All Fields</option>
+                <option value="title">Title</option>
+                <option value="author">Author</option>
+                <option value="subject">Subject</option>
+                <!--<option value="hlb">Academic Discipline</option>-->
+                <!--<option value="callnumber">Call Number / in progress</option>-->
+                <option value="isn">ISBN/ISSN</option>
+                <option value="publisher">Publisher</option>
+                <option value="series">Series Title</option>
+                <option value="year">Year of Publication</option>
+                <!-- <option value="tag">Tag</option> -->
+              </select>
+              <input type="hidden" name="sethtftonly" value="true" />
+              <input
+                type="checkbox"
+                name="htftonly"
+                value="true"
+                id="fullonly"
+                checked="yes"
+                style="position: relative; font-size: 13px"
+              />&nbsp;<label
+                for="fullonly"
+                style="position: relative; font-family: Arial, Verdana, Helvetica, sans-serif; font-size: 12px"
+                >Full view only</label
+              >
+            </div>
+            <div style="margin-bottom: 2px">
+              <label class="offscreen" for="searchfilter">Filter by Library</label>
+              <select id="searchfilter" name="filter[]" style="font-size: 13px; width: 238px">
+                <option value="">All Libraries</option>
+                <option value="htsource:Boston College">Boston College</option>
+                <option value="htsource:Columbia University">Columbia University</option>
+                <option value="htsource:Cornell University">Cornell University</option>
+                <option value="htsource:Duke University">Duke University</option>
+                <option value="htsource:Harvard University">Harvard University</option>
+                <option value="htsource:Indiana University">Indiana University</option>
+                <option value="htsource:Library of Congress">Library of Congress</option>
+                <option value="htsource:Minnesota Digital Library">Minnesota Digital Library</option>
+                <option value="htsource:New York Public Library">New York Public Library</option>
+                <option value="htsource:North Carolina State University">North Carolina State University</option>
+                <option value="htsource:Northwestern University">Northwestern University</option>
+                <option value="htsource:Penn State University">Penn State University</option>
+                <option value="htsource:Princeton University">Princeton University</option>
+                <option value="htsource:Purdue University">Purdue University</option>
+                <option value="htsource:Universidad Complutense de Madrid">Universidad Complutense de Madrid</option>
+                <option value="htsource:University of California">University of California</option>
+                <option value="htsource:University of Chicago">University of Chicago</option>
+                <option value="htsource:University of Florida">University of Florida</option>
+                <option value="htsource:University of Illinois">University of Illinois</option>
+                <option value="htsource:University of Michigan">University of Michigan</option>
+                <option value="htsource:University of Minnesota">University of Minnesota</option>
+                <option value="htsource:University of North Carolina">University of North Carolina</option>
+                <option value="htsource:University of Virginia">University of Virginia</option>
+                <option value="htsource:University of Wisconsin">University of Wisconsin</option>
+                <option value="htsource:Utah State University Press">Utah State University Press</option>
+                <option value="htsource:Yale University">Yale University</option>
+              </select>
+            </div>
+          </form>
+        </div>
+      </div>
+    </main>
+    <script type="text/javascript" src="/wp-content/themes/wordpress-hathitrust/src/js/matomo.js"></script>
+  </body>
+</html>

--- a/src/js/testing-matomo.js
+++ b/src/js/testing-matomo.js
@@ -1,0 +1,11 @@
+//use testing matomo for dev, staging sites
+var _mtm = (window._mtm = window._mtm || []);
+_mtm.push({ 'mtm.startTime': new Date().getTime(), event: 'mtm.Start' });
+(function () {
+  var d = document,
+    g = d.createElement('script'),
+    s = d.getElementsByTagName('script')[0];
+  g.async = true;
+  g.src = 'https://testing.matomo.hathitrust.org/js/container_JBgjlXyE.js';
+  s.parentNode.insertBefore(g, s);
+})();


### PR DESCRIPTION
The search widgets needed a branding update, so I took this opportunity to move them under the wordpress umbrella. I copy-and-pasted the old widget code and updated the styles to fit in the same size iframe as the current widgets. I'm sure there is a more "wordpress" way to do this, but this got the job done without too much fuss. 

### This PR includes:
- new page templates for each updated widget
- restructuring of the scripts/styles enqueueing in `functions.php` and an addition of a dev script for matomo tracking

These changes are the code portion of this update. 

### Before deploying this PR, I still need to:
- make new wordpress pages (top-level, e.g. `hathitrust.org/searchbox_multi`)
- create redirects (e.g. `/widgets/searchbox_multi.html` → `/searchbox_multi/`)

### And after deploying: 
- add variables, trigger, and tag to production matomo, publish new version
- update widget embed codes to use new URLs

All of this is already in place, working, and tested on [beta-1.www](https://beta-1.www.hathitrust.org/testing-updated-widgets/) and testing.matomo. See conversation on [DEV-954](https://hathitrust.atlassian.net/browse/DEV-954) for more details.

Thanks to redirects, the updated widgets are backward-compatible with current widget code our member institutions already have in place. Going forward, the new embed codes will use the new wordpress URLs.