### PR TITLE
update widget embed codes with new urls

### DIFF
--- a/page-widgets.php
+++ b/page-widgets.php
@@ -46,11 +46,11 @@
             <div class="pb widget-container">
                 
                     <h2>Catalog Search with Multiple Options</h2>
-                    <iframe id="iframe_htCatalogSearch01" style="border: 0; margin: 0 3px; overflow: hidden" width="451" height="91"><a href="https://catalog.hathitrust.org">Search the HathiTrust Digital Library Catalog</a></iframe><script type="text/javascript">var ht_url = "https://www.hathitrust.org/widgets/searchbox_multi.html?referrer=" + window.location.hostname;document.getElementById("iframe_htCatalogSearch01").contentWindow.document.location.href = ht_url;</script>
+                    <iframe id="iframe_htCatalogSearch01" style="border: 0; margin: 0 3px; overflow: hidden" width="451" height="91"><a href="https://catalog.hathitrust.org">Search the HathiTrust Digital Library Catalog</a></iframe><script type="text/javascript">var ht_url = "https://www.hathitrust.org/searchbox_multi/?referrer=" + window.location.hostname;document.getElementById("iframe_htCatalogSearch01").contentWindow.document.location.href = ht_url;</script>
                     <form>
                         <div>
                             <label for="widgetcode_01">Copy Code Snippet:</label>
-                            <input type="text" id="widgetcode_01" style="font-family:monospace;" value='<iframe id="iframe_htCatalogSearch01" style="border: 0; margin: 0 3px; overflow: hidden" width="451" height="91"><a href="https://catalog.hathitrust.org">Search the HathiTrust Digital Library Catalog</a></iframe><script type="text/javascript">var ht_url = "https://www.hathitrust.org/widgets/searchbox_multi.html?referrer=" + window.location.hostname;document.getElementById("iframe_htCatalogSearch01").contentWindow.document.location.href = ht_url;</script>'>
+                            <input type="text" id="widgetcode_01" style="font-family:monospace;" value='<iframe id="iframe_htCatalogSearch01" style="border: 0; margin: 0 3px; overflow: hidden" width="451" height="91"><a href="https://catalog.hathitrust.org">Search the HathiTrust Digital Library Catalog</a></iframe><script type="text/javascript">var ht_url = "https://www.hathitrust.org/searchbox_multi/?referrer=" + window.location.hostname;document.getElementById("iframe_htCatalogSearch01").contentWindow.document.location.href = ht_url;</script>'>
                         </div>
                     </form>
               
@@ -58,44 +58,44 @@
        
             <div class="pb widget-container">
                 <h2>Catalog Search</h2>
-                <iframe id="iframe_htCatalogSearch02" style="border: 0; margin: 0 3px; overflow: hidden" width="294" height="26"><a href="https://catalog.hathitrust.org">Search the HathiTrust Digital Library Catalog</a></iframe><script type="text/javascript">var ht_url = 'https://www.hathitrust.org/widgets/searchbox_catalog.html?referrer=' + window.location.hostname;document.getElementById('iframe_htCatalogSearch02').contentWindow.document.location.href = ht_url;</script>
+                <iframe id="iframe_htCatalogSearch02" style="border: 0; margin: 0 3px; overflow: hidden" width="294" height="26"><a href="https://catalog.hathitrust.org">Search the HathiTrust Digital Library Catalog</a></iframe><script type="text/javascript">var ht_url = 'https://www.hathitrust.org/searchbox_catalog/?referrer=' + window.location.hostname;document.getElementById('iframe_htCatalogSearch02').contentWindow.document.location.href = ht_url;</script>
                 <form>
                     <div>
                         <label for="widgetcode_02">Copy Code Snippet:</label>
-                        <input type="text" id="widgetcode_02" style="font-family:monospace;" value='<iframe id="iframe_htCatalogSearch02" style="border: 0; margin: 0 3px; overflow: hidden" width="294" height="26"><a href="https://catalog.hathitrust.org">Search the HathiTrust Digital Library Catalog</a></iframe><script type="text/javascript">var ht_url = "https://www.hathitrust.org/widgets/searchbox_catalog.html?referrer=" + window.location.hostname;document.getElementById("iframe_htCatalogSearch02").contentWindow.document.location.href = ht_url;</script>'>
+                        <input type="text" id="widgetcode_02" style="font-family:monospace;" value='<iframe id="iframe_htCatalogSearch02" style="border: 0; margin: 0 3px; overflow: hidden" width="294" height="26"><a href="https://catalog.hathitrust.org">Search the HathiTrust Digital Library Catalog</a></iframe><script type="text/javascript">var ht_url = "https://www.hathitrust.org/searchbox_catalog/?referrer=" + window.location.hostname;document.getElementById("iframe_htCatalogSearch02").contentWindow.document.location.href = ht_url;</script>'>
                     </div>
                 </form>
             </div>
 
             <div class="pb widget-container">
                 <h2>Catalog Search with Full View Option</h2>
-                <iframe id="iframe_htCatalogSearch03" style="border: 0; margin: 0 3px; overflow: hidden" width="300" height="63" ><a href="https://catalog.hathitrust.org">Search the HathiTrust Digital Library Catalog</a></iframe><script type="text/javascript">var ht_url = 'https://www.hathitrust.org/widgets/searchbox_catalog_fv.html?referrer=' + window.location.hostname;document.getElementById('iframe_htCatalogSearch03').contentWindow.document.location.href = ht_url;</script>
+                <iframe id="iframe_htCatalogSearch03" style="border: 0; margin: 0 3px; overflow: hidden" width="300" height="63" ><a href="https://catalog.hathitrust.org">Search the HathiTrust Digital Library Catalog</a></iframe><script type="text/javascript">var ht_url = 'https://www.hathitrust.org/searchbox_catalog_fv/?referrer=' + window.location.hostname;document.getElementById('iframe_htCatalogSearch03').contentWindow.document.location.href = ht_url;</script>
                 <form>
                     <div>
                         <label for="widgetcode_03">Copy Code Snippet:</label>
-                        <input type="text" id="widgetcode_03" style="font-family:monospace;" value='<iframe id="iframe_htCatalogSearch03" style="border: 0; margin: 0 3px; overflow: hidden" width="300" height="63" ><a href="https://catalog.hathitrust.org">Search the HathiTrust Digital Library Catalog</a></iframe><script type="text/javascript">var ht_url = "https://www.hathitrust.org/widgets/searchbox_catalog_fv.html?referrer=" + window.location.hostname;document.getElementById("iframe_htCatalogSearch03").contentWindow.document.location.href = ht_url;</script>'>
+                        <input type="text" id="widgetcode_03" style="font-family:monospace;" value='<iframe id="iframe_htCatalogSearch03" style="border: 0; margin: 0 3px; overflow: hidden" width="300" height="63" ><a href="https://catalog.hathitrust.org">Search the HathiTrust Digital Library Catalog</a></iframe><script type="text/javascript">var ht_url = "https://www.hathitrust.org/searchbox_catalog_fv/?referrer=" + window.location.hostname;document.getElementById("iframe_htCatalogSearch03").contentWindow.document.location.href = ht_url;</script>'>
                     </div>
                 </form>
             </div>
 
             <div class="pb widget-container">
                 <h2>Full Text Search</h2>
-                <iframe id="iframe_htFullTextSearch01" style="border: 0; margin: 0 3px; overflow: hidden" width="294" height="26"><a href="https://catalog.hathitrust.org">Search the HathiTrust Digital Library Catalog</a></iframe><script type="text/javascript">var ht_url = 'https://www.hathitrust.org/widgets/searchbox_fulltext.html?referrer=' + window.location.hostname;document.getElementById('iframe_htFullTextSearch01').contentWindow.document.location.href = ht_url;</script>
+                <iframe id="iframe_htFullTextSearch01" style="border: 0; margin: 0 3px; overflow: hidden" width="294" height="26"><a href="https://catalog.hathitrust.org">Search the HathiTrust Digital Library Catalog</a></iframe><script type="text/javascript">var ht_url = 'https://www.hathitrust.org/searchbox_fulltext/?referrer=' + window.location.hostname;document.getElementById('iframe_htFullTextSearch01').contentWindow.document.location.href = ht_url;</script>
                 <form>
                     <div>
                         <label for="widgetcode_04">Copy Code Snippet:</label>
-                        <input type="text" id="widgetcode_04" style="font-family:monospace;" value='<iframe id="iframe_htFullTextSearch01" style="border: 0; margin: 0 3px; overflow: hidden" width="294" height="26"><a href="https://catalog.hathitrust.org">Search the HathiTrust Digital Library Catalog</a></iframe><script type="text/javascript">var ht_url = "https://www.hathitrust.org/widgets/searchbox_fulltext.html?referrer=" + window.location.hostname;document.getElementById("iframe_htFullTextSearch01").contentWindow.document.location.href = ht_url;</script>'>
+                        <input type="text" id="widgetcode_04" style="font-family:monospace;" value='<iframe id="iframe_htFullTextSearch01" style="border: 0; margin: 0 3px; overflow: hidden" width="294" height="26"><a href="https://catalog.hathitrust.org">Search the HathiTrust Digital Library Catalog</a></iframe><script type="text/javascript">var ht_url = "https://www.hathitrust.org/searchbox_fulltext/?referrer=" + window.location.hostname;document.getElementById("iframe_htFullTextSearch01").contentWindow.document.location.href = ht_url;</script>'>
                     </div>
                 </form>
             </div>
 
             <div class="pb widget-container">
                 <h2>Full Text Search with Full View Option</h2>
-                <iframe id="iframe_htFullTextSearch02" style="border: 0; margin: 0 3px; overflow: hidden" width="300" height="63"><a href="https://catalog.hathitrust.org">Search the HathiTrust Digital Library Catalog</a></iframe><script type="text/javascript">var ht_url = 'https://www.hathitrust.org/widgets/searchbox_fulltext_fv.html?referrer=' + window.location.hostname;document.getElementById('iframe_htFullTextSearch02').contentWindow.document.location.href = ht_url;</script>
+                <iframe id="iframe_htFullTextSearch02" style="border: 0; margin: 0 3px; overflow: hidden" width="300" height="63"><a href="https://catalog.hathitrust.org">Search the HathiTrust Digital Library Catalog</a></iframe><script type="text/javascript">var ht_url = 'https://www.hathitrust.org/searchbox_fulltext_fv/?referrer=' + window.location.hostname;document.getElementById('iframe_htFullTextSearch02').contentWindow.document.location.href = ht_url;</script>
                 <form>
                     <div>
                         <label for="widgetcode_05">Copy Code Snippet:</label>
-                        <input type="text" id="widgetcode_05" style="font-family:monospace;" value='<iframe id="iframe_htFullTextSearch02" style="border: 0; margin: 0 3px; overflow: hidden" width="300" height="63"><a href="https://catalog.hathitrust.org">Search the HathiTrust Digital Library Catalog</a></iframe><script type="text/javascript">var ht_url = "https://www.hathitrust.org/widgets/searchbox_fulltext_fv.html?referrer=" + window.location.hostname;document.getElementById("iframe_htFullTextSearch02").contentWindow.document.location.href = ht_url;</script>'>
+                        <input type="text" id="widgetcode_05" style="font-family:monospace;" value='<iframe id="iframe_htFullTextSearch02" style="border: 0; margin: 0 3px; overflow: hidden" width="300" height="63"><a href="https://catalog.hathitrust.org">Search the HathiTrust Digital Library Catalog</a></iframe><script type="text/javascript">var ht_url = "https://www.hathitrust.org/searchbox_fulltext_fv/?referrer=" + window.location.hostname;document.getElementById("iframe_htFullTextSearch02").contentWindow.document.location.href = ht_url;</script>'>
                     </div>
                 </form>
             </div>


### PR DESCRIPTION
The new search widgets have been deployed; the wordpress site has pages for them all; the redirects are in place; the old widgets have been moved out of the way. The last step of the process is to update the old embed codes with the new URLs. 🎉 