### PR TITLE
Hide alert banner

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -324,6 +324,7 @@ hathi-website-header {
 }
 hathi-alert-banner {
   grid-area: banner;
+  display: none;
 }
 hathi-website-footer {
   grid-area: footer;


### PR DESCRIPTION
In the future, the visbility and text of the alert banner should be driven by something external, but this seems like the simplest change to hide it for the time being.