### PR TITLE
edit rsync deploy_dest

### DIFF
--- a/bin/rsync.app
+++ b/bin/rsync.app
@@ -3,7 +3,7 @@
 DEST_PREFIX=$1
 shift
 
-DEPLOY_DEST=${DEST_PREFIX}www/wordpress-hathitrust
+DEPLOY_DEST=${DEST_PREFIX}www/
 DEPLOY_SRC=/htapps/test.www/wordpress-hathitrust
 
 EXCLUDE=$(cat <<EOT


### PR DESCRIPTION
Change deploy destination so we don't have `wordpress-hathitrust` copied into `www` instead of `wordpress-hathitrust`.