### PR TITLE
DEV-1251: remove YouTube video from homepage

### DIFF
--- a/acf-json/group_6401f51290bb6.json
+++ b/acf-json/group_6401f51290bb6.json
@@ -416,7 +416,7 @@
         },
         {
             "key": "field_6401f57f4a4a9",
-            "label": "Presentations",
+            "label": "Training",
             "name": "",
             "aria-label": "",
             "type": "tab",
@@ -433,8 +433,8 @@
         },
         {
             "key": "field_640218c61c730",
-            "label": "Presentations",
-            "name": "presentations",
+            "label": "Training",
+            "name": "training",
             "aria-label": "",
             "type": "group",
             "instructions": "",
@@ -527,8 +527,8 @@
                 },
                 {
                     "key": "field_640219f05c3d1",
-                    "label": "YouTube",
-                    "name": "youtube",
+                    "label": "Image",
+                    "name": "image",
                     "aria-label": "",
                     "type": "group",
                     "instructions": "",
@@ -543,10 +543,10 @@
                     "sub_fields": [
                         {
                             "key": "field_640218dedda50",
-                            "label": "Video ID",
-                            "name": "video_id",
+                            "label": "Image from Media Library",
+                            "name": "med_img",
                             "aria-label": "",
-                            "type": "text",
+                            "type": "image",
                             "instructions": "",
                             "required": 1,
                             "conditional_logic": 0,
@@ -555,18 +555,23 @@
                                 "class": "",
                                 "id": ""
                             },
-                            "default_value": "",
-                            "maxlength": "",
-                            "placeholder": "",
-                            "prepend": "",
-                            "append": ""
+                            "return_format": "array",
+                            "library": "all",
+                            "min_width": "",
+                            "min_height": "",
+                            "min_size": "",
+                            "max_width": "",
+                            "max_height": "",
+                            "max_size": "",
+                            "mime_types": "",
+                            "preview_size": "medium"
                         },
                         {
                             "key": "field_640219ff5c3d2",
-                            "label": "Video Title",
-                            "name": "video_title",
+                            "label": "Training URL",
+                            "name": "url",
                             "aria-label": "",
-                            "type": "text",
+                            "type": "url",
                             "instructions": "",
                             "required": 1,
                             "conditional_logic": 0,
@@ -575,11 +580,8 @@
                                 "class": "",
                                 "id": ""
                             },
-                            "default_value": "",
-                            "maxlength": "",
-                            "placeholder": "",
-                            "prepend": "",
-                            "append": ""
+                            "default_value": "URL of training material, linked from image",
+                            "placeholder": ""
                         }
                     ]
                 }
@@ -756,5 +758,5 @@
     "active": true,
     "description": "",
     "show_in_rest": 0,
-    "modified": 1678389489
+    "modified": 1722541634
 }

--- a/front-page.php
+++ b/front-page.php
@@ -116,23 +116,11 @@
 	</div>
 <?php
 
-			$pres = get_field( 'presentations' );
+			// $pres = get_field( 'presentations' );
+			$training = get_field( 'training' );
 
 ?>
-	<div class="home-pres">
-		<div class="yt-no-consent pres-card">
-				<img src="/wp-content/themes/wordpress-hathitrust/images/yt/new_website.jpg" alt=""/>
-				<div class="d-flex align-items-center gap-2">
-					<i class="fa-brands fa-youtube fa-fw fa-xl" aria-hidden="true"></i><a target="_blank" rel="noopener" class="text-decoration-underline fw-bold d-inline" href="https://www.youtube.com/watch?v=<?= $pres['youtube']['video_id'] ?>">Video: <?= esc_attr( $pres['youtube']['video_title'] ); ?><i class="fa-solid fa-arrow-up-right-from-square fa-fw ps-2" aria-hidden="true"></i></a>
-				</div>
-				<p class="small">This YouTube video has been disabled by your cookie selection. You can watch this video on YouTube: <a target="_blank" rel="noopener" class="text-decoration-underline" href="https://www.youtube.com/watch?v=<?= $pres['youtube']['video_id'] ?>"><?= esc_attr( $pres['youtube']['video_title'] ); ?></a><span class="visually-hidden">(opens in a new tab)</span>.</p>
-		</div>
-		<iframe loading="lazy" width="508" height="285" data-cookieblock-src="<?= esc_url( 'https://www.youtube-nocookie.com/embed/' . $pres['youtube']['video_id'] . '?modestbranding=1&rel=0&enablejsapi=1' ); ?>" title="<?= esc_attr( $pres['youtube']['video_title'] ); ?>"></iframe>
-		<div class="hpres-content">
-			<a href="<?= esc_url( $pres['cta']['url'] ); ?>" class="allcaps link-arrow"><span><?= esc_html( $pres['cta']['label'] ); ?></span></a>
-			<div class="hpres-copy"><?= wp_kses_post( $pres['content'] ); ?></div>
-		</div>
-	</div>
+	
 	<section class="home-fc">
 		<h2 class="h3 allcaps">Featured Collections</h2>
 		<div class="home-fc-cards">
@@ -162,6 +150,15 @@
 ?>
 		</div>
 	</section>
+	<div class="home-pres">
+		<div class="yt-no-consent pres-card">
+				<a href="<?= esc_url( $training['image']['url'] ); ?>"><img src="<?= esc_url( $training['image']['med_img']['url'] ); ?>" alt=""/></a>
+		</div>
+		<div class="hpres-content">
+			<a href="<?= esc_url( $training['cta']['url'] ); ?>" class="allcaps link-arrow"><span><?= esc_html( $training['cta']['label'] ); ?></span></a>
+			<div class="hpres-copy"><?= wp_kses_post( $training['content'] ); ?></div>
+		</div>
+	</div>
 </div>
 <?php
 

--- a/src/css/home.css
+++ b/src/css/home.css
@@ -214,7 +214,7 @@
   object-fit: cover;
   width: 100%;
   border-radius: 0.375rem;
-  filter: brightness(0.6);
+  aspect-ratio:16/9;
 }
 
 /* FEATURED COLLECTIONS */

--- a/src/js/cookies.js
+++ b/src/js/cookies.js
@@ -55,25 +55,6 @@ function removeCookie(sKey, sPath, sDomain) {
   return true;
 }
 
-function loadYouTubeVideo() {
-  if (window.location.pathname !== '/') {
-    return;
-  }
-
-  let placeholder = document.querySelector('.yt-no-consent');
-
-  if (!placeholder) {
-    return;
-  }
-
-  let youtubeVideo = document.querySelector('.home-pres iframe');
-  let youtubeSrc = youtubeVideo.getAttribute('data-cookieblock-src');
-
-  youtubeVideo.src = youtubeSrc;
-  youtubeVideo.removeAttribute('data-cookieblock-src');
-  placeholder.remove();
-}
-
 function loadMapEmbed() {
   if (!window.location.pathname.includes('member-list')) {
     return;
@@ -89,7 +70,6 @@ function loadMapEmbed() {
 
 function checkForCookies() {
   if (getCookie('HT-marketing-cookie-consent') === 'true') {
-    loadYouTubeVideo();
     loadMapEmbed();
   }
   if (getCookie('HT-tracking-cookie-consent') === 'true') {


### PR DESCRIPTION
Fixes issue #31 

Jessica and I discussed how she would like to rearrange the homepage to take advantage of needing to remove the YouTube video from the "Presentations" block of content. 

Specs: 

- swap “Featured Collections” and “Presentation” sections on the homepage
- rename “Presentation” section to “Training”
- update the ACF in Presentation/Training from a video/youtube link to use an image from the media library with a link to a training resource

I created new custom fields with the ACF plugin, then swapped those fields in for the previous YouTube content block fields. I then moved the whole "presentation" block to the bottom of the page, as requested.

I also removed the javascript function that loaded the YouTube video when the marketing cookie was set. (We still need the marketing cookie because we have the map embed on the member libraries page.)

Reviewer: check that my php isn't ridiculous and see it in action on [dev-3](https://dev-3.www.hathitrust.org/).

In theory, when I deploy this theme, the ACF plugin should detect the differences in the JSON files and I should be able to "sync" them. The only ACF pro plugin with an active license is on prod, so I can't test that. However, if that doesn't work, I can manually swap out the ACF fields in about 2 minutes and fix the homepage content in another 2.