### PR TITLE
DEV-1095: remove alert banner display none

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -324,7 +324,6 @@ hathi-website-header {
 }
 hathi-alert-banner {
   grid-area: banner;
-  display: none;
 }
 hathi-website-footer {
   grid-area: footer;


### PR DESCRIPTION
One-line style change to remove "display:none" for the alert banner.