### PR TITLE
ETT-586: fix feedback modal button

### DIFF
--- a/inc/block-feedback_form.php
+++ b/inc/block-feedback_form.php
@@ -2,10 +2,9 @@
 	<h2 id="<?= sanitize_title_with_dashes( $heading ); ?>" class="pb-heading allcaps"><?= esc_html( get_sub_field( 'heading' ) ); ?></h2>
 	<div class="pb">
 		<div class="pb-contents"><?= wp_kses_post( get_sub_field( 'contents' ) ); ?></div>
-		<div class="pb-link" data-hathi-trigger="hathi-feedback-form-modal" id="feedback-form">
+		<div class="pb-link" data-hathi-trigger="hathi-feedback-form-modal" data-prop-form="contact" data-prop-is-open="false" id="feedback-form" >
 			<button type="button" class="btn btn-primary"><span><?= get_sub_field( 'label' ); ?></span></button>
 		</div>
 	</div>
-	<hathi-feedback-form-modal data-prop-form="basic" data-prop-is-open="false"></hathi-feedback-form-modal">
 </div>
 


### PR DESCRIPTION
This update reflects the changes to firebird-common in svelte 5 (see hathitrust/firebird-common#126). The `data-hathi-trigger` attribute value of `hathi-feedback-form-modal` is already creating the feedback form modal, so I removed the `<hathi-feedback-form-modal>` element here and moved the props to the trigger element where they belong.

Due to an a11y tweak, I also changed the `data-prop-form` attribute value to `contact` so we can return the focus to the CTA button when the keyboard closes the modal.

This is up on dev-3 at https://dev-3.www.hathitrust.org/contact/