### PR TITLE
update button styles for modal conflict

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -195,7 +195,7 @@ h3,
 }
 
 /* utility classes */
-.btn {
+.btn:not(dialog .btn) { /*all buttons not in modals; styles were conflicting with firebird modal styles*/
   display: inline-flex;
   gap: 0.75rem;
   align-items: center;


### PR DESCRIPTION
Very small tweak to the wordpress theme stylesheet that ensures all buttons inside modals aren't affected by the global `.btn` styles in the rest of the theme.

<img width="3170" height="1444" alt="image" src="https://github.com/user-attachments/assets/7d556beb-3708-4451-8ef7-1478312b47cf" />
It's very subtle, but the modal on the right has slightly less padding in the buttons than what is currently on prod as shown on the left.

~~This isn't staged on dev-3 anymore, but Gayathri already approved it during UI review.~~ I restaged it on dev-3 for testing! If you go to https://dev-3.www.hathitrust.org/ and click LOG IN from the navbar, you can see the buttons don't look like they have a bunch of extra padding anymore.