### PR TITLE
ETT-17: remove netlify fallback links from enqueue function; refactor function

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -25,26 +25,20 @@
 	 */
 	function pg_enqueue_site_files() {
 
-		$firebird_manifest = array(
-			'stylesheet' => '//hathitrust-firebird-common.netlify.app/assets/index.css',
-			'script' => '//hathitrust-firebird-common.netlify.app/assets/index.js'
-		);
 		$BABEL_ROOT = str_replace('www', 'babel', $_SERVER['DOCUMENT_ROOT']);
+		$manifest = json_decode(
+			file_get_contents($BABEL_ROOT . '/firebird-common/dist/manifest.json'),
+			true
+		);
 
-		$firebird_manifest_filename = $BABEL_ROOT . '/firebird-common/dist/manifest.json';
+		$base_path = ('local' === wp_get_environment_type())
+			? '/firebird-common/dist/'
+			: '/common/firebird/dist/';
 
-		if ( file_exists(($firebird_manifest_filename)) ) {
-			$firebird_config = json_decode(file_get_contents($firebird_manifest_filename), true);
-
-			$firebird_manifest['stylesheet'] = '/common/firebird/dist/' . $firebird_config['index.css']['file'];
-			$firebird_manifest['script'] = '/common/firebird/dist/' . $firebird_config['index.html']['file'];
-
-			//firebird-common installed and built at wp install level
-			if ('local' === wp_get_environment_type()) {
-				$firebird_manifest['stylesheet'] = '/firebird-common/dist/' . $firebird_config['index.css']['file'];
-				$firebird_manifest['script'] =  '/firebird-common/dist/' . $firebird_config['index.html']['file'];
-			}
-		}
+		$firebird_manifest = [
+			'stylesheet' => $base_path . $manifest['index.css']['file'],
+			'script'     => $base_path . $manifest['index.html']['file'],
+		];
 
 		/*
 		STYLES


### PR DESCRIPTION
Removed the netlify links that were standing in as 'default' links and refactored the function to clean it up a bit. This is [staged on dev-3](https://dev-3.www.hathitrust.org) and nothing looks broken.