### PR TITLE
a11y: SiteImprov fixes

### DIFF
--- a/page-strategic-vision.php
+++ b/page-strategic-vision.php
@@ -64,7 +64,7 @@
                         Direction 1: Increase Access and Use
                     </button>
                     </h2>
-                    <div id="panelsStayOpen-collapseOne" class="accordion-collapse collapse show" aria-labelledby="panelsStayOpen-headingOne">
+                    <div id="panelsStayOpen-collapseOne" class="accordion-collapse collapse show">
                     <div class="accordion-body">
                         <p>We will expand access to and increase use of copyrighted, open, and public domain works in the HathiTrust collection.</p>
                         <p class="bold">Objectives</p>
@@ -84,7 +84,7 @@
                         Direction 2: Expand and Diversify the Collection
                     </button>
                     </h2>
-                    <div id="panelsStayOpen-collapseTwo" class="accordion-collapse collapse" aria-labelledby="panelsStayOpen-headingTwo">
+                    <div id="panelsStayOpen-collapseTwo" class="accordion-collapse collapse">
                     <div class="accordion-body">
                         <p>We will expand the volume and diversity of book and serial content in the HathiTrust collection.</p>
                         <p class="bold">Objectives</p>
@@ -103,7 +103,7 @@
                         Direction 3: Enrich Texts and Metadata
                     </button>
                     </h2>
-                    <div id="panelsStayOpen-collapseThree" class="accordion-collapse collapse" aria-labelledby="panelsStayOpen-headingThree">
+                    <div id="panelsStayOpen-collapseThree" class="accordion-collapse collapse">
                     <div class="accordion-body">
                         <p>We will enable new forms of discovery, access, and use of the HathiTrust collection through large-scale enhancement of texts and metadata.</p>
                         <p class="bold">Objectives</p>
@@ -121,7 +121,7 @@
                         Direction 4: Invest In Core, Enabling Infrastructure
                     </button>
                     </h2>
-                    <div id="panelsStayOpen-collapseFour" class="accordion-collapse collapse" aria-labelledby="panelsStayOpen-headingFour">
+                    <div id="panelsStayOpen-collapseFour" class="accordion-collapse collapse">
                     <div class="accordion-body">
                     <p>We will reinforce our technological and operational foundations to preserve and steward the HathiTrust collection responsibly, sustainably, and effectively.</p>
                     <p class="bold">Objectives</p>

--- a/page-widgets.php
+++ b/page-widgets.php
@@ -44,21 +44,19 @@
 
         
             <div class="pb widget-container">
-                
-                    <h2>Catalog Search with Multiple Options</h2>
-                    <iframe id="iframe_htCatalogSearch01" style="border: 0; margin: 0 3px; overflow: hidden" width="451" height="91"><a href="https://catalog.hathitrust.org">Search the HathiTrust Digital Library Catalog</a></iframe><script type="text/javascript">var ht_url = "https://www.hathitrust.org/searchbox_multi/?referrer=" + window.location.hostname;document.getElementById("iframe_htCatalogSearch01").contentWindow.document.location.href = ht_url;</script>
-                    <form>
-                        <div>
-                            <label for="widgetcode_01">Copy Code Snippet:</label>
-                            <input type="text" id="widgetcode_01" style="font-family:monospace;" value='<iframe id="iframe_htCatalogSearch01" style="border: 0; margin: 0 3px; overflow: hidden" width="451" height="91"><a href="https://catalog.hathitrust.org">Search the HathiTrust Digital Library Catalog</a></iframe><script type="text/javascript">var ht_url = "https://www.hathitrust.org/searchbox_multi/?referrer=" + window.location.hostname;document.getElementById("iframe_htCatalogSearch01").contentWindow.document.location.href = ht_url;</script>'>
-                        </div>
-                    </form>
-              
+                <h2>Catalog Search with Multiple Options</h2>
+                <iframe id="iframe_htCatalogSearch01" style="border: 0; margin: 0 3px; overflow: hidden" width="451" height="91" title="Widget to Search the HathiTrust Digital Library Catalog with multiple options"><a href="https://catalog.hathitrust.org">Search the HathiTrust Digital Library Catalog</a></iframe><script type="text/javascript">var ht_url = "https://www.hathitrust.org/searchbox_multi/?referrer=" + window.location.hostname;document.getElementById("iframe_htCatalogSearch01").contentWindow.document.location.href = ht_url;</script>
+                <form>
+                    <div>
+                        <label for="widgetcode_01">Copy Code Snippet:</label>
+                        <input type="text" id="widgetcode_01" style="font-family:monospace;" value='<iframe id="iframe_htCatalogSearch01" style="border: 0; margin: 0 3px; overflow: hidden" width="451" height="91"><a href="https://catalog.hathitrust.org">Search the HathiTrust Digital Library Catalog</a></iframe><script type="text/javascript">var ht_url = "https://www.hathitrust.org/searchbox_multi/?referrer=" + window.location.hostname;document.getElementById("iframe_htCatalogSearch01").contentWindow.document.location.href = ht_url;</script>'>
+                    </div>
+                </form>
             </div>
        
             <div class="pb widget-container">
                 <h2>Catalog Search</h2>
-                <iframe id="iframe_htCatalogSearch02" style="border: 0; margin: 0 3px; overflow: hidden" width="294" height="26"><a href="https://catalog.hathitrust.org">Search the HathiTrust Digital Library Catalog</a></iframe><script type="text/javascript">var ht_url = 'https://www.hathitrust.org/searchbox_catalog/?referrer=' + window.location.hostname;document.getElementById('iframe_htCatalogSearch02').contentWindow.document.location.href = ht_url;</script>
+                <iframe id="iframe_htCatalogSearch02" style="border: 0; margin: 0 3px; overflow: hidden" width="294" height="26" title="Widget to Search the HathiTrust Digital Library Catalog"><a href="https://catalog.hathitrust.org">Search the HathiTrust Digital Library Catalog</a></iframe><script type="text/javascript">var ht_url = 'https://www.hathitrust.org/searchbox_catalog/?referrer=' + window.location.hostname;document.getElementById('iframe_htCatalogSearch02').contentWindow.document.location.href = ht_url;</script>
                 <form>
                     <div>
                         <label for="widgetcode_02">Copy Code Snippet:</label>
@@ -69,7 +67,7 @@
 
             <div class="pb widget-container">
                 <h2>Catalog Search with Full View Option</h2>
-                <iframe id="iframe_htCatalogSearch03" style="border: 0; margin: 0 3px; overflow: hidden" width="300" height="63" ><a href="https://catalog.hathitrust.org">Search the HathiTrust Digital Library Catalog</a></iframe><script type="text/javascript">var ht_url = 'https://www.hathitrust.org/searchbox_catalog_fv/?referrer=' + window.location.hostname;document.getElementById('iframe_htCatalogSearch03').contentWindow.document.location.href = ht_url;</script>
+                <iframe id="iframe_htCatalogSearch03" style="border: 0; margin: 0 3px; overflow: hidden" width="300" height="63" title="Widget to Search the HathiTrust Digital Library Catalog with Full-view option"><a href="https://catalog.hathitrust.org">Search the HathiTrust Digital Library Catalog</a></iframe><script type="text/javascript">var ht_url = 'https://www.hathitrust.org/searchbox_catalog_fv/?referrer=' + window.location.hostname;document.getElementById('iframe_htCatalogSearch03').contentWindow.document.location.href = ht_url;</script>
                 <form>
                     <div>
                         <label for="widgetcode_03">Copy Code Snippet:</label>
@@ -80,7 +78,7 @@
 
             <div class="pb widget-container">
                 <h2>Full Text Search</h2>
-                <iframe id="iframe_htFullTextSearch01" style="border: 0; margin: 0 3px; overflow: hidden" width="294" height="26"><a href="https://catalog.hathitrust.org">Search the HathiTrust Digital Library Catalog</a></iframe><script type="text/javascript">var ht_url = 'https://www.hathitrust.org/searchbox_fulltext/?referrer=' + window.location.hostname;document.getElementById('iframe_htFullTextSearch01').contentWindow.document.location.href = ht_url;</script>
+                <iframe id="iframe_htFullTextSearch01" style="border: 0; margin: 0 3px; overflow: hidden" width="294" height="26" title="Widget to Search the HathiTrust Digital Library Catalogy Full-Text"><a href="https://catalog.hathitrust.org">Search the HathiTrust Digital Library Catalog</a></iframe><script type="text/javascript">var ht_url = 'https://www.hathitrust.org/searchbox_fulltext/?referrer=' + window.location.hostname;document.getElementById('iframe_htFullTextSearch01').contentWindow.document.location.href = ht_url;</script>
                 <form>
                     <div>
                         <label for="widgetcode_04">Copy Code Snippet:</label>
@@ -91,7 +89,7 @@
 
             <div class="pb widget-container">
                 <h2>Full Text Search with Full View Option</h2>
-                <iframe id="iframe_htFullTextSearch02" style="border: 0; margin: 0 3px; overflow: hidden" width="300" height="63"><a href="https://catalog.hathitrust.org">Search the HathiTrust Digital Library Catalog</a></iframe><script type="text/javascript">var ht_url = 'https://www.hathitrust.org/searchbox_fulltext_fv/?referrer=' + window.location.hostname;document.getElementById('iframe_htFullTextSearch02').contentWindow.document.location.href = ht_url;</script>
+                <iframe id="iframe_htFullTextSearch02" style="border: 0; margin: 0 3px; overflow: hidden" width="300" height="63" title="Widget to Search the HathiTrust Digital Library Catalog Full-text with full-view option"><a href="https://catalog.hathitrust.org">Search the HathiTrust Digital Library Catalog</a></iframe><script type="text/javascript">var ht_url = 'https://www.hathitrust.org/searchbox_fulltext_fv/?referrer=' + window.location.hostname;document.getElementById('iframe_htFullTextSearch02').contentWindow.document.location.href = ht_url;</script>
                 <form>
                     <div>
                         <label for="widgetcode_05">Copy Code Snippet:</label>


### PR DESCRIPTION
We have just two tiny things left on the SiteImprov Issues page: 

1. accordions on the Strategic Vision page have an `aria-labelledby` on a `<div>` (which is an invalid use of ARIA, and we're working on fixing that throughout the site/apps, see [ETT-1168](https://hathitrust.atlassian.net/browse/ETT-1168)), so I deleted those ARIA tags.
2. iframes for the search widgets were missing a text alternative, so I added a title to each of the five widgets.

[ETT-1168]: https://hathitrust.atlassian.net/browse/ETT-1168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ