### PR TITLE
allow title attribute for iframes

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -206,6 +206,7 @@
 				'loading'			=> TRUE,
 				'src'				=> TRUE,
 				'width'				=> TRUE,
+				'title'				=> TRUE,
 			);
 		}
 


### PR DESCRIPTION
I added a title for the [embed iframes](https://www.hathitrust.org/member-libraries/resources-for-librarians/improve-discovery/embed-hathitrust-books/) to fix an issue listed on SiteImprov, but the latest crawl indicated that my fix didn't work.  I was baffled to find that the titles I added to those iframes was not showing up in the markup on the page. Turns out, we have a filter for acceptable attributes on iframes and all other attributes get stripped by wp. I added the title attribute to the "allowed tags" array.