### PR TITLE
Page holdings checker improvements

### DIFF
--- a/page-print-holdings-checker.php
+++ b/page-print-holdings-checker.php
@@ -33,7 +33,7 @@
                 <input type="file" id="file-input" class="file-input" multiple accept=".tsv" aria-hidden="true" tabindex="-1">
             </div>
 
-            <div id="output" class="checker-output" style="display:none" tabindex="-1" aria-label="Results"></div>
+            <div id="output" class="checker-output" style="display:none" tabindex="-1" aria-label="Results" aria-live="polite"></div>
 
         </div>
     </div>

--- a/src/css/print-holdings-checker.css
+++ b/src/css/print-holdings-checker.css
@@ -86,6 +86,36 @@
     margin-top: 0.25rem;
 }
 
+.file-card--pending {
+    border-left-color: var(--neutral300);
+}
+
+.file-card-spinner {
+    display: inline-block;
+    width: 1rem;
+    height: 1rem;
+    border: 2px solid var(--neutral300);
+    border-top-color: var(--neutral600);
+    border-radius: 50%;
+    animation: checker-spin 0.8s linear infinite;
+}
+
+@keyframes checker-spin {
+    to { transform: rotate(360deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .file-card-spinner {
+        animation: none;
+        border-top-color: var(--neutral300);
+    }
+}
+
+.checker-clear-btn {
+    align-self: flex-start;
+    margin-top: 0.5rem;
+}
+
 .checker-drop-error {
     border-left: 4px solid var(--primary500);
     background: var(--primary100);

--- a/src/js/print-holdings-checker/index.js
+++ b/src/js/print-holdings-checker/index.js
@@ -20,6 +20,7 @@ if (dropZone) {
   document.getElementById('file-button').addEventListener('click', () => fileInput.click());
   fileInput.addEventListener('change', (event) => {
     const files = [...event.target.files];
+    fileInput.value = ''; // reset so the same file can be re-selected after clearing results
     const invalid = files.filter(f => !f.name.toLowerCase().endsWith('.tsv'));
     if (invalid.length > 0) {
       showError(outputContainer, `Only .tsv files are supported. Unsupported file${invalid.length > 1 ? 's' : ''}: ${invalid.map(f => f.name).join(', ')}`);
@@ -89,7 +90,7 @@ async function processFileList(fileList) {
 
   const errorCount = results.filter(Boolean).length;
   const label = errorCount === 0
-    ? `Results: all ${fileList.length} file${fileList.length > 1 ? 's' : ''} passed`
+    ? `Results: all ${fileList.length} file${fileList.length > 1 ? 's' : ''} passed with no errors`
     : `Results: ${errorCount} of ${fileList.length} file${fileList.length > 1 ? 's' : ''} have errors`;
   outputContainer.setAttribute('aria-label', label);
 

--- a/src/js/print-holdings-checker/index.js
+++ b/src/js/print-holdings-checker/index.js
@@ -1,5 +1,11 @@
-import { validateFile, allowedTypes } from './validate.js';
+import { validateFile, validateRows, allowedTypes } from './validate.js';
 import { buildCard, buildPendingCard, showError } from './ui.js';
+
+// Fetch is CORS-blocked outside www.hathitrust.org (local dev, test); catch returns null and member ID check is silently skipped.
+const memberIdsPromise = fetch('https://www.hathitrust.org/files/ht_institutions.tsv')
+  .then(r => r.text())
+  .then(text => new Set(text.split('\n').filter(Boolean).map(line => line.split('\t')[0])))
+  .catch(() => null);
 
 const outputContainer = document.getElementById('output');
 const dropZone = document.getElementById('drop-zone');
@@ -14,7 +20,7 @@ if (dropZone) {
   document.getElementById('file-button').addEventListener('click', () => fileInput.click());
   fileInput.addEventListener('change', (event) => {
     const files = [...event.target.files];
-    const invalid = files.filter(f => !f.name.endsWith('.tsv'));
+    const invalid = files.filter(f => !f.name.toLowerCase().endsWith('.tsv'));
     if (invalid.length > 0) {
       showError(outputContainer, `Only .tsv files are supported. Unsupported file${invalid.length > 1 ? 's' : ''}: ${invalid.map(f => f.name).join(', ')}`);
       return;
@@ -53,7 +59,7 @@ function dropHandler(event) {
   }
 
   const files = [...event.dataTransfer.files];
-  const invalid = files.filter(f => !f.name.endsWith('.tsv'));
+  const invalid = files.filter(f => !f.name.toLowerCase().endsWith('.tsv'));
   if (invalid.length > 0) {
     showError(outputContainer, `Only .tsv files are supported. Unsupported file${invalid.length > 1 ? 's' : ''}: ${invalid.map(f => f.name).join(', ')}`);
     return;
@@ -71,6 +77,11 @@ async function processFileList(fileList) {
     outputContainer.appendChild(card);
     return card;
   });
+
+  // Focus before and after: first announces "Processing…" on focus (VoiceOver/Safari ignores aria-live on display:none containers);
+  // second announces the final result label once processing completes.
+  outputContainer.setAttribute('aria-label', `Processing ${fileList.length} file${fileList.length !== 1 ? 's' : ''}…`);
+  outputContainer.focus();
 
   const results = await Promise.all(
     fileList.map((file, i) => processFile(file, pendingCards[i]))
@@ -96,29 +107,45 @@ async function processFileList(fileList) {
   outputContainer.focus();
 }
 
+const ROW_SAMPLE_LIMIT = 1000;
+
 async function processFile(file, pendingCard) {
   try {
-    const text = await file.text();
+    const buffer = await file.arrayBuffer();
+    const encodingErrors = [];
+    let text;
+    // fatal: true throws on bad bytes; fall back to lenient decode so validation still runs.
+    try {
+      text = new TextDecoder('utf-8', { fatal: true }).decode(buffer);
+    } catch {
+      encodingErrors.push('File does not appear to be UTF-8 encoded - some characters may be misread');
+      text = new TextDecoder('utf-8').decode(buffer);
+    }
     const lines = text.split(/\r\n|\r|\n/);
     if (lines.at(-1) === '') lines.pop();
     const totalLines = lines.length;
     const firstLine = lines.shift();
     if (firstLine === undefined) {
-      pendingCard.replaceWith(buildCard({ fileName: file.name, displayType: '—', columns: [], totalLines: 0, errors: [] }));
-      return false;
+      pendingCard.replaceWith(buildCard({ fileName: file.name, displayType: '-', columns: [], totalLines: 0, rowsChecked: 0, sampled: false, errors: encodingErrors }));
+      return encodingErrors.length > 0;
     }
-    return report(file, firstLine, totalLines, pendingCard);
+    const sampled = lines.length > ROW_SAMPLE_LIMIT;
+    const dataRows = lines.slice(0, ROW_SAMPLE_LIMIT);
+    const memberIds = await memberIdsPromise;
+    return report({ file, firstLine, totalLines, dataRows, sampled, pendingCard, memberIds, encodingErrors });
   } catch {
-    pendingCard.replaceWith(buildCard({ fileName: file.name, displayType: '—', columns: [], totalLines: 0, errors: ['Could not read file'] }));
+    pendingCard.replaceWith(buildCard({ fileName: file.name, displayType: '-', columns: [], totalLines: 0, rowsChecked: 0, sampled: false, errors: ['Could not read file'] }));
     return true;
   }
 }
 
-function report(file, firstLine, totalLines, pendingCard) {
+function report({ file, firstLine, totalLines, dataRows, sampled, pendingCard, memberIds, encodingErrors }) {
   const columns = firstLine.split('\t');
-  const { type, errors } = validateFile(file.name, columns);
-  const displayType = (type in allowedTypes) ? type : '—';
-  const card = buildCard({ fileName: file.name, displayType, columns, totalLines, errors });
+  const { type, errors: headerErrors } = validateFile(file.name, columns, memberIds);
+  const rowErrors = validateRows(columns, dataRows);
+  const errors = [...encodingErrors, ...headerErrors, ...rowErrors];
+  const displayType = (type in allowedTypes) ? type : '-';
+  const card = buildCard({ fileName: file.name, displayType, columns, totalLines, rowsChecked: dataRows.length, sampled, errors });
   pendingCard.replaceWith(card);
   return errors.length > 0;
 }

--- a/src/js/print-holdings-checker/index.js
+++ b/src/js/print-holdings-checker/index.js
@@ -1,11 +1,10 @@
-import { validateFile } from './validate.js';
-import { buildCard, showError } from './ui.js';
+import { validateFile, allowedTypes } from './validate.js';
+import { buildCard, buildPendingCard, showError } from './ui.js';
 
 const outputContainer = document.getElementById('output');
+const dropZone = document.getElementById('drop-zone');
 
-addEventListener('load', () => {
-  const dropZone = document.getElementById('drop-zone');
-  if (!dropZone) return;
+if (dropZone) {
   dropZone.addEventListener('drop', dropHandler);
   dropZone.addEventListener('dragover', dragOverHandler);
   dropZone.addEventListener('dragenter', dragEnterHandler);
@@ -22,7 +21,7 @@ addEventListener('load', () => {
     }
     processFileList(files);
   });
-});
+}
 
 function dragOverHandler(event) {
   event.preventDefault();
@@ -30,17 +29,17 @@ function dragOverHandler(event) {
 
 function dragEnterHandler(event) {
   event.preventDefault();
-  this.classList.add('drag-over');
+  event.currentTarget.classList.add('drag-over');
 }
 
 function dragLeaveHandler(event) {
   event.preventDefault();
-  this.classList.remove('drag-over');
+  event.currentTarget.classList.remove('drag-over');
 }
 
 function dropHandler(event) {
   event.preventDefault();
-  this.classList.remove('drag-over');
+  event.currentTarget.classList.remove('drag-over');
 
   const items = [...event.dataTransfer.items];
   for (const item of items) {
@@ -63,43 +62,63 @@ function dropHandler(event) {
   processFileList(files);
 }
 
-function processFileList(fileList) {
+async function processFileList(fileList) {
   outputContainer.replaceChildren();
   outputContainer.style.display = 'flex';
-  let remaining = fileList.length;
-  let errorCount = 0;
-  fileList.forEach(file => processFile(file, (hasErrors) => {
-    if (hasErrors) errorCount++;
-    remaining--;
-    if (remaining === 0) {
-      const label = errorCount === 0
-        ? `Results: all ${fileList.length} file${fileList.length > 1 ? 's' : ''} passed`
-        : `Results: ${errorCount} of ${fileList.length} file${fileList.length > 1 ? 's' : ''} have errors`;
-      outputContainer.setAttribute('aria-label', label);
-      outputContainer.focus();
-    }
-  }));
+
+  const pendingCards = fileList.map(file => {
+    const card = buildPendingCard(file.name);
+    outputContainer.appendChild(card);
+    return card;
+  });
+
+  const results = await Promise.all(
+    fileList.map((file, i) => processFile(file, pendingCards[i]))
+  );
+
+  const errorCount = results.filter(Boolean).length;
+  const label = errorCount === 0
+    ? `Results: all ${fileList.length} file${fileList.length > 1 ? 's' : ''} passed`
+    : `Results: ${errorCount} of ${fileList.length} file${fileList.length > 1 ? 's' : ''} have errors`;
+  outputContainer.setAttribute('aria-label', label);
+
+  const clearBtn = document.createElement('button');
+  clearBtn.type = 'button';
+  clearBtn.className = 'btn btn-secondary checker-clear-btn';
+  clearBtn.textContent = 'Clear results';
+  clearBtn.addEventListener('click', () => {
+    outputContainer.replaceChildren();
+    outputContainer.style.display = 'none';
+    outputContainer.setAttribute('aria-label', 'Results');
+  });
+  outputContainer.appendChild(clearBtn);
+
+  outputContainer.focus();
 }
 
-function processFile(file, onComplete) {
-  const reader = new FileReader();
-  reader.onload = () => {
-    const text = reader.result;
+async function processFile(file, pendingCard) {
+  try {
+    const text = await file.text();
     const lines = text.split(/\r\n|\r|\n/);
     if (lines.at(-1) === '') lines.pop();
     const totalLines = lines.length;
     const firstLine = lines.shift();
-    const hasErrors = firstLine !== undefined ? report(file, firstLine, totalLines) : false;
-    onComplete(hasErrors);
-  };
-  reader.onerror = () => onComplete(false);
-  reader.readAsText(file, 'UTF-8');
+    if (firstLine === undefined) {
+      pendingCard.replaceWith(buildCard({ fileName: file.name, displayType: '—', columns: [], totalLines: 0, errors: [] }));
+      return false;
+    }
+    return report(file, firstLine, totalLines, pendingCard);
+  } catch {
+    pendingCard.replaceWith(buildCard({ fileName: file.name, displayType: '—', columns: [], totalLines: 0, errors: ['Could not read file'] }));
+    return true;
+  }
 }
 
-function report(file, firstLine, totalLines) {
+function report(file, firstLine, totalLines, pendingCard) {
   const columns = firstLine.split('\t');
   const { type, errors } = validateFile(file.name, columns);
-  const card = buildCard({ fileName: file.name, type, columns, totalLines, errors });
-  outputContainer.appendChild(card);
+  const displayType = (type in allowedTypes) ? type : '—';
+  const card = buildCard({ fileName: file.name, displayType, columns, totalLines, errors });
+  pendingCard.replaceWith(card);
   return errors.length > 0;
 }

--- a/src/js/print-holdings-checker/ui.js
+++ b/src/js/print-holdings-checker/ui.js
@@ -19,7 +19,7 @@ export function buildPendingCard(fileName) {
   return card;
 }
 
-export function buildCard({ fileName, displayType, columns, totalLines, errors }) {
+export function buildCard({ fileName, displayType, columns, totalLines, rowsChecked, sampled, errors }) {
   const hasErrors = errors.length > 0;
 
   const card = document.createElement('article');
@@ -45,7 +45,8 @@ export function buildCard({ fileName, displayType, columns, totalLines, errors }
   meta.className = 'file-card-meta';
   const metaFields = [
     ['Type', displayType],
-    ['Total lines', totalLines],
+    ['Data rows', (totalLines - 1).toLocaleString()],
+    ...(sampled ? [['Rows checked', `${rowsChecked.toLocaleString()} (large file, first ${rowsChecked.toLocaleString()} rows only)`]] : []),
     ['Columns', columns.join(', ')],
   ];
   for (const [label, value] of metaFields) {

--- a/src/js/print-holdings-checker/ui.js
+++ b/src/js/print-holdings-checker/ui.js
@@ -1,6 +1,25 @@
-import { allowedTypes } from './validate.js';
+export function buildPendingCard(fileName) {
+  const card = document.createElement('article');
+  card.className = 'file-card file-card--pending';
+  card.setAttribute('aria-label', `${fileName}, processing`);
+  card.setAttribute('aria-busy', 'true');
 
-export function buildCard({ fileName, type, columns, totalLines, errors }) {
+  const header = document.createElement('div');
+  header.className = 'file-card-header';
+  const fileNameHeading = document.createElement('h2');
+  fileNameHeading.className = 'file-card-name h3';
+  fileNameHeading.textContent = fileName;
+  const spinner = document.createElement('span');
+  spinner.className = 'file-card-spinner';
+  spinner.setAttribute('aria-hidden', 'true');
+  header.appendChild(fileNameHeading);
+  header.appendChild(spinner);
+  card.appendChild(header);
+
+  return card;
+}
+
+export function buildCard({ fileName, displayType, columns, totalLines, errors }) {
   const hasErrors = errors.length > 0;
 
   const card = document.createElement('article');
@@ -25,7 +44,7 @@ export function buildCard({ fileName, type, columns, totalLines, errors }) {
   const meta = document.createElement('dl');
   meta.className = 'file-card-meta';
   const metaFields = [
-    ['Type', (type in allowedTypes) ? type : '—'],
+    ['Type', displayType],
     ['Total lines', totalLines],
     ['Columns', columns.join(', ')],
   ];

--- a/src/js/print-holdings-checker/validate.js
+++ b/src/js/print-holdings-checker/validate.js
@@ -127,14 +127,19 @@ export function validateRows(columns, dataRows) {
     }
 
     if (oclcIdx >= 0 && oclcIdx < fields.length) {
-      const ocn = fields[oclcIdx].trim();
-      if (ocn !== '') {
-        if (/\d+\.?\d*[eE][+\-]?\d+/.test(ocn)) {
-          scientificNotation.push(ocn);
-        } else if (/^99\d+$/.test(ocn) && ocn.length > 15) {
-          almaMmsIds.push(ocn);
-        } else if (!/^\d+$/.test(ocn) || ocn === '0') {
-          invalidOcns.push(ocn);
+      const ocnField = fields[oclcIdx].trim();
+      if (ocnField !== '') {
+        for (const part of ocnField.split(/[,:;|/ ]+/).map(s => s.trim()).filter(Boolean)) {
+          if (/\d+\.?\d*[eE][+\-]?\d+/.test(part)) {
+            scientificNotation.push(part);
+          } else {
+            const numeric = stripOcnPrefix(part);
+            if (numeric === null || !/^\d+$/.test(numeric) || numeric === '0') {
+              invalidOcns.push(part);
+            } else if (/^99/.test(numeric) && numeric.length > 15) {
+              almaMmsIds.push(numeric);
+            }
+          }
         }
       }
     }
@@ -166,7 +171,7 @@ export function validateRows(columns, dataRows) {
   if (almaMmsIds.length > 0)
     errors.push(`${almaMmsIds.length} apparent Alma MMS ID${almaMmsIds.length !== 1 ? 's' : ''} in oclc column (e.g. ${examples(almaMmsIds)}) - replace with OCLC numbers`);
   if (invalidOcns.length > 0)
-    errors.push(`${invalidOcns.length} invalid OCN${invalidOcns.length !== 1 ? 's' : ''} - must be a positive integer (e.g. ${examples(invalidOcns)})`);
+    errors.push(`${invalidOcns.length} invalid OCN${invalidOcns.length !== 1 ? 's' : ''} - must be digits or a prefixed number like ocn12345 or (OCoLC)12345 (e.g. ${examples(invalidOcns)})`);
   if (invalidStatus.length > 0)
     errors.push(`${invalidStatus.length} invalid status value${invalidStatus.length !== 1 ? 's' : ''} - must be CH, LM, WD, or empty (got ${examples(invalidStatus)})`);
   if (invalidCondition.length > 0)
@@ -181,6 +186,21 @@ function linesSummary(singular, plural, lineNums) {
   const isPlural = lineNums.length !== 1;
   const shown = lineNums.slice(0, 5).join(', ') + (lineNums.length > 5 ? '…' : '');
   return `${lineNums.length} ${isPlural ? plural : singular} (line${isPlural ? 's' : ''}: ${shown})`;
+}
+
+// Strips known OCN prefixes ((OCoLC), ocm, ocn, etc.) and returns the numeric string.
+// Handles nested prefixes like (OCoLC)ocm12345. Returns null for unrecognized paren prefixes.
+function stripOcnPrefix(val) {
+  let result = val;
+  if (/^\((oclc|ocm|ocn|ocolc|on)\)/i.test(result)) {
+    result = result.replace(/^\(.+?\)/, '');
+  } else if (/^\(.+?\)/.test(result)) {
+    return null;
+  }
+  if (/^(oclc|ocm|ocn|ocolc|on)/i.test(result)) {
+    result = result.replace(/^\D+/, '');
+  }
+  return result;
 }
 
 function examples(values) {

--- a/src/js/print-holdings-checker/validate.js
+++ b/src/js/print-holdings-checker/validate.js
@@ -26,21 +26,22 @@ export const allowedTypes = {
   }
 };
 
-export function validateFile(fileName, columns) {
+export function validateFile(fileName, columns, memberIds = null) {
   const errors = [];
-  const type = validateFilename(fileName, errors);
+  const type = validateFilename(fileName, errors, memberIds);
   if (type !== null) {
     errors.push(...checkFields(type, columns));
   }
   return { type, errors };
 }
 
-function validateFilename(fileName, errors) {
-  if (!fileName.endsWith('.tsv')) {
+function validateFilename(fileName, errors, memberIds) {
+  const lowerName = fileName.toLowerCase();
+  if (!lowerName.endsWith('.tsv')) {
     errors.push(`File extension must be .tsv`);
   }
 
-  const baseName = fileName.endsWith('.tsv') ? fileName.slice(0, -4) : fileName;
+  const baseName = lowerName.endsWith('.tsv') ? fileName.slice(0, -4) : fileName;
   const parts = baseName.split('_');
 
   if (parts.length < 4) {
@@ -48,12 +49,17 @@ function validateFilename(fileName, errors) {
     return null;
   }
 
+  const memberId = parts.slice(0, -3).join('_');
   const type = parts.at(-3);
   const updateType = parts.at(-2);
   const date = parts.at(-1);
 
+  if (memberIds !== null && !memberIds.has(memberId)) {
+    errors.push(`'${memberId}' is not a recognized HathiTrust member ID`);
+  }
+
   if (!(type in allowedTypes)) {
-    errors.push(`'${type}' is not a recognized holdings type (should be one of mix, mon, mpm, ser, spm)`);
+    errors.push(`'${type}' is not a recognized holdings type (must be one of mix, mon, mpm, ser, spm)`);
   }
 
   if (updateType !== 'full') {
@@ -63,7 +69,7 @@ function validateFilename(fileName, errors) {
   if (!/^\d{8}$/.test(date)) {
     errors.push(`Date must be 8 digits in YYYYMMDD format (got '${date}')`);
   } else if (!isValidCalendarDate(date)) {
-    errors.push(`'${date}' is not a valid calendar date`);
+    errors.push(`'${date}' is not a valid calendar date - date must be in YYYYMMDD format`);
   }
 
   return (type in allowedTypes) ? type : null;
@@ -74,7 +80,111 @@ function isValidCalendarDate(dateStr) {
   const month = parseInt(dateStr.slice(4, 6), 10);
   const day = parseInt(dateStr.slice(6, 8), 10);
   const d = new Date(year, month - 1, day);
+  // JS normalizes overflowed dates (Feb 30 -> Mar 2), so if any component changed, the original was invalid.
   return d.getFullYear() === year && d.getMonth() === month - 1 && d.getDate() === day;
+}
+
+export function validateRows(columns, dataRows) {
+  const errors = [];
+
+  const oclcIdx = columns.indexOf('oclc');
+  const statusIdx = columns.indexOf('status');
+  const conditionIdx = columns.indexOf('condition');
+  const govdocIdx = columns.indexOf('govdoc');
+
+  const emptyLines = [];
+  const nonTabLines = [];
+  const wrongColumnCount = [];
+  const scientificNotation = [];
+  const almaMmsIds = [];
+  const invalidOcns = [];
+  const invalidStatus = [];
+  const invalidCondition = [];
+  const invalidGovdoc = [];
+
+  const VALID_STATUS = new Set(['CH', 'LM', 'WD', '']);
+  const VALID_CONDITION = new Set(['BRT', '']);
+  const VALID_GOVDOC = new Set(['0', '1', '']);
+
+  for (let i = 0; i < dataRows.length; i++) {
+    const row = dataRows[i];
+    const lineNum = i + 2; // 1-based, skipping header
+
+    if (row === '') {
+      emptyLines.push(lineNum);
+      continue;
+    }
+
+    if (!row.includes('\t') && row.includes(',')) {
+      nonTabLines.push(lineNum);
+      continue;
+    }
+
+    const fields = row.split('\t');
+
+    if (fields.length !== columns.length) {
+      wrongColumnCount.push(lineNum);
+    }
+
+    if (oclcIdx >= 0 && oclcIdx < fields.length) {
+      const ocn = fields[oclcIdx].trim();
+      if (ocn !== '') {
+        if (/\d+\.?\d*[eE][+\-]?\d+/.test(ocn)) {
+          scientificNotation.push(ocn);
+        } else if (/^99\d+$/.test(ocn) && ocn.length > 15) {
+          almaMmsIds.push(ocn);
+        } else if (!/^\d+$/.test(ocn) || ocn === '0') {
+          invalidOcns.push(ocn);
+        }
+      }
+    }
+
+    if (statusIdx >= 0 && statusIdx < fields.length) {
+      const val = fields[statusIdx].trim();
+      if (!VALID_STATUS.has(val)) invalidStatus.push(val);
+    }
+
+    if (conditionIdx >= 0 && conditionIdx < fields.length) {
+      const val = fields[conditionIdx].trim();
+      if (!VALID_CONDITION.has(val)) invalidCondition.push(val);
+    }
+
+    if (govdocIdx >= 0 && govdocIdx < fields.length) {
+      const val = fields[govdocIdx].trim();
+      if (!VALID_GOVDOC.has(val)) invalidGovdoc.push(val);
+    }
+  }
+
+  if (emptyLines.length > 0)
+    errors.push(linesSummary('empty line', 'empty lines', emptyLines));
+  if (nonTabLines.length > 0)
+    errors.push(linesSummary('row uses comma separators instead of tabs - re-export as tab-separated (.tsv)', 'rows use comma separators instead of tabs - re-export as tab-separated (.tsv)', nonTabLines));
+  if (wrongColumnCount.length > 0)
+    errors.push(linesSummary('row with wrong column count', 'rows with wrong column count', wrongColumnCount));
+  if (scientificNotation.length > 0)
+    errors.push(`${scientificNotation.length} OCN${scientificNotation.length !== 1 ? 's' : ''} in scientific notation (e.g. ${examples(scientificNotation)}) - likely reformatted by Excel`);
+  if (almaMmsIds.length > 0)
+    errors.push(`${almaMmsIds.length} apparent Alma MMS ID${almaMmsIds.length !== 1 ? 's' : ''} in oclc column (e.g. ${examples(almaMmsIds)}) - replace with OCLC numbers`);
+  if (invalidOcns.length > 0)
+    errors.push(`${invalidOcns.length} invalid OCN${invalidOcns.length !== 1 ? 's' : ''} - must be a positive integer (e.g. ${examples(invalidOcns)})`);
+  if (invalidStatus.length > 0)
+    errors.push(`${invalidStatus.length} invalid status value${invalidStatus.length !== 1 ? 's' : ''} - must be CH, LM, WD, or empty (got ${examples(invalidStatus)})`);
+  if (invalidCondition.length > 0)
+    errors.push(`${invalidCondition.length} invalid condition value${invalidCondition.length !== 1 ? 's' : ''} - must be BRT or empty (got ${examples(invalidCondition)})`);
+  if (invalidGovdoc.length > 0)
+    errors.push(`${invalidGovdoc.length} invalid govdoc value${invalidGovdoc.length !== 1 ? 's' : ''} - must be 0, 1, or empty (got ${examples(invalidGovdoc)})`);
+
+  return errors;
+}
+
+function linesSummary(singular, plural, lineNums) {
+  const isPlural = lineNums.length !== 1;
+  const shown = lineNums.slice(0, 5).join(', ') + (lineNums.length > 5 ? '…' : '');
+  return `${lineNums.length} ${isPlural ? plural : singular} (line${isPlural ? 's' : ''}: ${shown})`;
+}
+
+function examples(values) {
+  return [...new Set(values)].slice(0, 3).map(v => `'${v}'`).join(', ');
 }
 
 function checkFields(type, columns) {

--- a/src/js/print-holdings-checker/validate.js
+++ b/src/js/print-holdings-checker/validate.js
@@ -27,19 +27,54 @@ export const allowedTypes = {
 };
 
 export function validateFile(fileName, columns) {
-  const parts = fileName.split('_');
-  const type = parts[1];
   const errors = [];
+  const type = validateFilename(fileName, errors);
+  if (type !== null) {
+    errors.push(...checkFields(type, columns));
+  }
+  return { type, errors };
+}
+
+function validateFilename(fileName, errors) {
+  if (!fileName.endsWith('.tsv')) {
+    errors.push(`File extension must be .tsv`);
+  }
+
+  const baseName = fileName.endsWith('.tsv') ? fileName.slice(0, -4) : fileName;
+  const parts = baseName.split('_');
 
   if (parts.length < 4) {
     errors.push(`Filename must follow the format: <member_id>_<type>_<update_type>_<date>.tsv`);
-  } else if (!(type in allowedTypes)) {
-    errors.push(`'${type}' is not a recognized holdings type (should be one of mix, mon, mpm, ser, spm)`);
-  } else {
-    errors.push(...checkFields(type, columns));
+    return null;
   }
 
-  return { type, errors };
+  const type = parts.at(-3);
+  const updateType = parts.at(-2);
+  const date = parts.at(-1);
+
+  if (!(type in allowedTypes)) {
+    errors.push(`'${type}' is not a recognized holdings type (should be one of mix, mon, mpm, ser, spm)`);
+  }
+
+  if (updateType !== 'full') {
+    errors.push(`Update type must be 'full' (got '${updateType}')`);
+  }
+
+  if (!/^\d{8}$/.test(date)) {
+    errors.push(`Date must be 8 digits in YYYYMMDD format (got '${date}')`);
+  } else if (!isValidCalendarDate(date)) {
+    errors.push(`'${date}' is not a valid calendar date`);
+  }
+
+  return (type in allowedTypes) ? type : null;
+}
+
+function isValidCalendarDate(dateStr) {
+  const year = parseInt(dateStr.slice(0, 4), 10);
+  const month = parseInt(dateStr.slice(4, 6), 10);
+  const day = parseInt(dateStr.slice(6, 8), 10);
+  const d = new Date(year, month - 1, day);
+  return d.getFullYear() === year && d.getMonth() === month - 1 && d.getDate() === day;
 }
 
 function checkFields(type, columns) {


### PR DESCRIPTION
This includes tickets ETT-1507 ETT-1508 ETT-1559 ETT-1560 ETT-1561 ETT-1563

You can check it out in dev at https://dev-3.www.hathitrust.org/print-holdings-checker/

### ETT-1559 - Code quality
I addressed security in the previous PR for this ticket.
In this PR I used `Promise.all` instead of a manual counter for parallel file processing. There's a few smaller cleanups too, file extension check is now case-insensitive so `.TSV` works.

#### Page loaded and valid .TSV accepted
<img width="1098" height="442" alt="image" src="https://github.com/user-attachments/assets/ac06c0cf-2ea8-49da-aa20-2c427889ad4f" />

### ETT-1560 - Filename validation

Here we check a bunch of things: file extension, member ID, holding type, update type, and date. `partial` is an error since the backend never implemented it. Date has to be YYYYMMDD and a real calendar date. Member ID is validated against the [HathiTrust institutions list](https://www.hathitrust.org/files/ht_institutions.tsv), fetched on load.

The institutions fetch is blocked by CORS everywhere except `www.hathitrust.org` itself, so the member id check only runs in production. It fails silently elsewhere (not blocking, the check is skipped in this case), so we only can realistically test it fully once it's in production.

#### Bad date in filename
<img width="1083" height="448" alt="image" src="https://github.com/user-attachments/assets/3ae7b9f0-af8f-4423-a46d-2775f8a35ec4" />

#### Partial update type rejected
<img width="1081" height="476" alt="image" src="https://github.com/user-attachments/assets/d3d516e8-6e87-467a-b4fe-05c6adbee064" />

#### Unrecognized member ID
<img width="1085" height="485" alt="image" src="https://github.com/user-attachments/assets/57c48965-9b94-469e-a2de-7850ce79ac08" />

### ETT-1561 - Loading states and accessibility

Each file gets a spinner icon indicator when it's drag dropped and processing is not done yet. Added `aria-live="polite"` to the results container. VoiceOver on Safari doesn't reliably announce live region updates on a container that starts as `display:none`, so we also set `aria-label` to "Processing N files..." and focus the container, which gets announced on focus instead. Clear results button appears after processing. Spinner respects `prefers-reduced-motion`.

#### Spinner loading state
<img width="1085" height="241" alt="image" src="https://github.com/user-attachments/assets/0bedfd20-5b74-4557-b12e-499c133da481" />

#### Multiple files - one pass, one error
<img width="1078" height="655" alt="image" src="https://github.com/user-attachments/assets/15f07fa0-1d36-470e-ae13-49df6d8c4bb3" />

### ETT-1507, ETT-1508, ETT-1563 - Data row validation

Checks the first 1,000 rows and notes on the card when a file was too large to check fully.
<img width="876" height="342" alt="image" src="https://github.com/user-attachments/assets/71d1d1e0-472f-4b0a-b31e-8d6b374bc5a0" />

If there were a lot of invalid status values:
<img width="879" height="299" alt="image" src="https://github.com/user-attachments/assets/873fb5b1-d2d7-48c3-86ca-ecc8963d3411" />

- Checks for empty lines, rows with comma separators instead of tabs (with hint to re export as tsv), and wrong column counts, with line numbers
- OCNs in scientific notation (Excel reformatting large integers), Alma MMS IDs (which start with `99`, over 15 digits, with hint to use OCLC numbers instead), and other non-integer values (must be a positive integer)
- Enforces that status must be `CH`, `LM`, `WD`, or empty. Condition must be `BRT` or empty. Govdoc must be `0`, `1`, or empty.

#### Data row errors
<img width="1064" height="726" alt="image" src="https://github.com/user-attachments/assets/82065af5-12c3-4b3f-98a5-66ee8e4f79e1" />

If there were a lot of rows with similar errors:
<img width="745" height="527" alt="image" src="https://github.com/user-attachments/assets/574d7603-4ff6-4761-b58f-ad630b9fe1a5" />

### Encoding detection

I used `TextDecoder` with `fatal: true` to detect non-UTF-8 files. If it throws, we warn the user and fall back to lenient decoding so the rest of the checks still run.

#### Non-UTF-8 encoding warning
<img width="889" height="394" alt="image" src="https://github.com/user-attachments/assets/e36e2732-e85d-4249-85a0-f510cb1a2321" />

### Rejected files

Non .tsv files get an inline error.

#### CSV rejected
<img width="1346" height="406" alt="image" src="https://github.com/user-attachments/assets/1e9d8d2c-67b9-4abf-8c48-1f5561514135" />

Created with help of AI